### PR TITLE
Spectral type recording adjustment

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -578,7 +578,8 @@ class AnalysisTools():
                 # Get stellar magnitudes and filter zero points, but use the same file as rawcon
                 ccinfo = os.path.join(rawcon_dir, 'contrast_curve_info.txt')
                 with open(ccinfo) as cci:
-                    starfile, spectral_type = cci.readline().strip('\n').split(' /// ')
+                    starfile, spectral_type_info = cci.readline().strip('\n').split(' /// ')
+                    spectral_type = spectral_type_info.split(': ')[1]
                     starfile = os.path.join(rawcon_dir, starfile.replace('#',''))
                 mstar, fzero = get_stellar_magnitudes(starfile,
                                                       spectral_type,

--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -145,10 +145,16 @@ class AnalysisTools():
             os.makedirs(output_dir)
 
         # Copy the starfile that will be used into this directory
-        starfile_ext = os.path.splitext(starfile)[1]
         new_starfile_path = output_dir+'/'+starfile.split('/')[-1]
-        new_header = '#'+starfile.split('/')[-1] + ' /// {}'.format(spectral_type)+'\n'
+        if starfile[-4:] == '.vot':
+            # Will be using the input spectral type, should record it
+            spectype_str = 'Spectral Type: {}'.format(spectral_type)
+        else:
+            # Spectral type won't be relevant, don't record misleading info
+            spectype_str = 'Spectral Type: N/A'
+        new_header = '#'+starfile.split('/')[-1] + f' /// {spectype_str}'+'\n'
         contrast_curve_info_path = output_dir+'/contrast_curve_info.txt'
+        # Also copy this info to the contrast curve file
         with open(contrast_curve_info_path, 'w') as ccinfo:
             ccinfo.write(new_header)
         log.info('Copying starfile {} to {}'.format(starfile, new_starfile_path))


### PR DESCRIPTION
This pull request includes updates to the `spaceKLIP/analysistools.py` file to improve the handling of spectral type information in the `raw_contrast` and `calibrate_contrast` methods. The most important changes include modifying how spectral type information is recorded and retrieved.

Improvements to spectral type handling:

* [`spaceKLIP/analysistools.py`](diffhunk://#diff-098183cac3279c94680a047d26e997539dfcb1ad12729e94b7d1aa8592e15e91L148-R157): Updated the `raw_contrast` method to conditionally include spectral type information based on the file extension and to ensure that this information is accurately recorded in the header.
* [`spaceKLIP/analysistools.py`](diffhunk://#diff-098183cac3279c94680a047d26e997539dfcb1ad12729e94b7d1aa8592e15e91L575-R582): Modified the `calibrate_contrast` method to correctly parse and retrieve the spectral type information from the contrast curve info file.