### PR TITLE
Adjust database path

### DIFF
--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -1245,28 +1245,33 @@ class Database():
         
         pass
 
-    def adjust_red_dir(self, red_dir):
+    def adjust_dir(self, dir_path, data_type):
         """
-        Adjust the directory of the reduced data products.
+        Adjust the directory of the data products.
 
         Parameters
         ----------
-        red_dir : str
-            New directory of the reduced data products.
+        dir_path : str
+            New directory of the data products.
+        data_type : str
+            Type of data to adjust ('red' for reduced data, 'obs' for observations data, 'src' for source data).
 
         Returns
         -------
         None.
 
         """
-        # Adjust the directory of the reduced data products.
+        # Adjust the directory of the data products.
         try:
-            for key in self.red.keys():
-                for i in range(len(self.red[key])):
-                    self.red[key]['FITSFILE'][i] = os.path.join(red_dir, os.path.split(self.red[key]['FITSFILE'][i])[1])
-                    self.red[key]['MASKFILE'][i] = os.path.join(red_dir, os.path.split(self.red[key]['MASKFILE'][i])[1])
+            data_dict = getattr(self, data_type)
+            for key in data_dict.keys():
+                for i in range(len(data_dict[key])):
+                    data_dict[key]['FITSFILE'][i] = os.path.join(dir_path,
+                                                                 os.path.split(data_dict[key]['FITSFILE'][i])[1])
+                    data_dict[key]['MASKFILE'][i] = os.path.join(dir_path,
+                                                                 os.path.split(data_dict[key]['MASKFILE'][i])[1])
         except Exception as e:
-            raise UserWarning(f"Invalid directory: {red_dir}. Error: {e}")
+            raise UserWarning(f"Invalid directory: {dir_path}. Error: {e}")
 
         pass
     

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -1244,6 +1244,31 @@ class Database():
             self.src[key] = [None] * index + [tab]
         
         pass
+
+    def adjust_red_dir(self, red_dir):
+        """
+        Adjust the directory of the reduced data products.
+
+        Parameters
+        ----------
+        red_dir : str
+            New directory of the reduced data products.
+
+        Returns
+        -------
+        None.
+
+        """
+        # Adjust the directory of the reduced data products.
+        try:
+            for key in self.red.keys():
+                for i in range(len(self.red[key])):
+                    self.red[key]['FITSFILE'][i] = os.path.join(red_dir, os.path.split(self.red[key]['FITSFILE'][i])[1])
+                    self.red[key]['MASKFILE'][i] = os.path.join(red_dir, os.path.split(self.red[key]['MASKFILE'][i])[1])
+        except Exception as e:
+            raise UserWarning(f"Invalid directory: {red_dir}. Error: {e}")
+
+        pass
     
     def summarize(self):
         """


### PR DESCRIPTION
This pull request introduces a new method to the `spaceKLIP/database.py` file to adjust the directory paths of data products. The only change is the addition of the `adjust_dir` method, which allows for updating the directory paths of various data types within the database.

Key changes include:

* Added `adjust_dir` method to `spaceKLIP/database.py` to update directory paths for data products based on their type ('red', 'obs', or 'src'). The method updates the paths for 'FITSFILE' and 'MASKFILE' entries and raises a `UserWarning` if the directory is invalid.