### PR TITLE
Track Mask and Star Center Individually

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -89,7 +89,7 @@ class AnalysisTools():
                      starfile,
                      spectral_type='G2V',
                      companions=None,
-                     overwrite_crpix=None,
+                     overwrite_starcen=None,
                      subdir='rawcon',
                      output_filetype='npy',
                      plot_xlim=(0,10),
@@ -111,8 +111,8 @@ class AnalysisTools():
             For each companion, there should be a three element list containing
             [RA offset (arcsec), Dec offset (arcsec), mask radius (lambda/D)].
             The default is None.
-        overwrite_crpix : tuple of two float, optional
-            Overwrite the PSF center with the (CRPIX1, CRPIX2) values provided
+        overwrite_starcen : tuple of two float, optional
+            Overwrite the PSF center with the (STARCENX, STARCENY) values provided
             here (in 1-indexed coordinates). This is required for Coron3 data!
             The default is None.
         subdir : str, optional
@@ -219,10 +219,10 @@ class AnalysisTools():
                     resolution = np.hypot(resolution, self.database.obs[key]['BLURFWHM'][j])
                 
                 # Get the star position.
-                if overwrite_crpix is None:
-                    center = (head_pri['CRPIX1'] - 1., head_pri['CRPIX2'] - 1.)  # pix (0-indexed)
+                if overwrite_starcen is None:
+                    center = (head_pri['STARCENX'] - 1., head_pri['STARCENY'] - 1.)  # pix (0-indexed)
                 else:
-                    center = (overwrite_crpix[0] - 1., overwrite_crpix[1] - 1.)  # pix (0-indexed)
+                    center = (overwrite_starcen[0] - 1., overwrite_starcen[1] - 1.)  # pix (0-indexed)
                 
                 # Mask coronagraph spiders, 4QPM edges, etc. 
                 if self.database.red[key]['EXP_TYPE'][j] in ['NRC_CORON']:

--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -558,7 +558,8 @@ class AnalysisTools():
                 # Read Stage 2 files and make pyKLIP dataset
                 filepaths, psflib_filepaths = get_pyklip_filepaths(self.database, key)
                 pop_pxar_kw(np.append(filepaths, psflib_filepaths))
-                pyklip_dataset = JWSTData(filepaths, psflib_filepaths)
+                pyklip_dataset = JWSTData(filepaths, psflib_filepaths,
+                                          center_keywords=['STARCENX','STARCENY'])
 
                 # Compute the resolution element. Account for possible blurring.
                 pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] # arcsec
@@ -1008,7 +1009,8 @@ class AnalysisTools():
                 
                 # Initialize pyKLIP dataset.
                 pop_pxar_kw(np.append(filepaths, psflib_filepaths))
-                dataset = JWSTData(filepaths, psflib_filepaths, highpass=highpass)
+                dataset = JWSTData(filepaths, psflib_filepaths, highpass=highpass,
+                                          center_keywords=['STARCENX','STARCENY'])
                 kwargs_temp['dataset'] = dataset
                 kwargs_temp['aligned_center'] = dataset._centers[0]
                 kwargs_temp['psf_library'] = dataset.psflib
@@ -1737,14 +1739,14 @@ class AnalysisTools():
                             
                             # Plot the pymultinest fit results.
                             fit.fit_plots()
-                            if save_figres:
+                            if save_figures:
                                 path = os.path.join(output_dir_comp, mode + '_NANNU' + str(annuli) + '_NSUBS' + str(subsections) + '_' + key + '-corner_c%.0f' % (k + 1) + '.pdf')
                                 plt.savefig(path)
                             plt.show()
                             plt.close(fig)
 
                             fit.fm_residuals()
-                            if save_figres:
+                            if save_figures:
                                 path = os.path.join(output_dir_comp, mode + '_NANNU' + str(annuli) + '_NSUBS' + str(subsections) + '_' + key + '-model_c%.0f' % (k + 1) + '.pdf')
                                 plt.savefig(path)
                             plt.show()

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -294,8 +294,8 @@ class Database():
 
             MASKCENX += [head.get('MASKCENX', float(CRPIX1[i]))]
             MASKCENY += [head.get('MASKCENY', float(CRPIX2[i]))]
-            STARCENX += [head.get('STARCENX', np.nan)]
-            STARCENY += [head.get('STARCENY', np.nan)]
+            STARCENX += [head.get('STARCENX', MASKCENX[-1])]
+            STARCENY += [head.get('STARCENY', MASKCENY[-1])]
             VPARITY += [head.get('VPARITY', -1)]
             V3I_YANG += [head.get('V3I_YANG', 0.)]
             RA_REF += [head.get('RA_REF', np.nan)]
@@ -1200,10 +1200,22 @@ class Database():
             New PSF y-offset (mas) for the observation to be updated. The
             default is None.
         crpix1 : float, optional
-            New PSF x-position (pix, 1-indexed) for the observation to be
+            New WCS reference x-position (pix, 1-indexed) for the observation to be
             updated. The default is None.
         crpix2 : float, optional
-            New PSF y-position (pix, 1-indexed) for the observation to be
+            New WCS reference y-position (pix, 1-indexed) for the observation to be
+            updated. The default is None.
+        maskcenx : float, optional
+            New mask x-position (pix, 1-indexed) for the observation to be
+            updated. The default is None.
+        maskceny : float, optional
+            New mask y-position (pix, 1-indexed) for the observation to be
+            updated. The default is None.
+        starcenx : float, optional
+            New star x-position (pix, 1-indexed) for the observation to be
+            updated. The default is None.
+        starceny : float, optional
+            New star y-position (pix, 1-indexed) for the observation to be
             updated. The default is None.
         blurfwhm : float, optional
             New FWHM for the Gaussian filter blurring (pix) for the observation

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -292,8 +292,8 @@ class Database():
                 CRPIX1 += [head.get('CRPIX1', np.nan)]
                 CRPIX2 += [head.get('CRPIX2', np.nan)]
 
-            MASKCENX += [head.get('MASKCENX', CRPIX1[i])]
-            MASKCENY += [head.get('MASKCENY', CRPIX2[i])]
+            MASKCENX += [head.get('MASKCENX', float(CRPIX1[i]))]
+            MASKCENY += [head.get('MASKCENY', float(CRPIX2[i]))]
             STARCENX += [head.get('STARCENX', np.nan)]
             STARCENY += [head.get('STARCENY', np.nan)]
             VPARITY += [head.get('VPARITY', -1)]

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -196,6 +196,10 @@ class Database():
         BUNIT = []
         CRPIX1 = []  # pix
         CRPIX2 = []  # pix
+        MASKCENX = [] # pix
+        MASKCENY = [] # pix
+        STARCENX = [] # pix
+        STARCENY = [] # pix
         VPARITY = []
         V3I_YANG = []  # deg
         RA_REF = []  # deg
@@ -287,6 +291,11 @@ class Database():
             else:
                 CRPIX1 += [head.get('CRPIX1', np.nan)]
                 CRPIX2 += [head.get('CRPIX2', np.nan)]
+
+            MASKCENX += [head.get('MASKCENX', CRPIX1[i])]
+            MASKCENY += [head.get('MASKCENY', CRPIX2[i])]
+            STARCENX += [head.get('STARCENX', np.nan)]
+            STARCENY += [head.get('STARCENY', np.nan)]
             VPARITY += [head.get('VPARITY', -1)]
             V3I_YANG += [head.get('V3I_YANG', 0.)]
             RA_REF += [head.get('RA_REF', np.nan)]
@@ -323,6 +332,10 @@ class Database():
         BUNIT = np.array(BUNIT)
         CRPIX1 = np.array(CRPIX1)
         CRPIX2 = np.array(CRPIX2)
+        MASKCENX = np.array(MASKCENX)
+        MASKCENY = np.array(MASKCENY)
+        STARCENX = np.array(STARCENX)
+        STARCENY = np.array(STARCENY)
         VPARITY = np.array(VPARITY)
         V3I_YANG = np.array(V3I_YANG)
         RA_REF = np.array(RA_REF)
@@ -421,6 +434,10 @@ class Database():
                                'BUNIT',
                                'CRPIX1',
                                'CRPIX2',
+                               'MASKCENX',
+                               'MASKCENY',
+                               'STARCENX',
+                               'STARCENY',
                                'RA_REF',
                                'DEC_REF',
                                'ROLL_REF',
@@ -453,6 +470,10 @@ class Database():
                                'float',
                                'float',
                                'object',
+                               'float',
+                               'float',
+                               'float',
+                               'float',
                                'float',
                                'float',
                                'float',
@@ -538,6 +559,10 @@ class Database():
                              BUNIT[ww][j],
                              CRPIX1[ww][j],
                              CRPIX2[ww][j],
+                             MASKCENX[ww][j],
+                             MASKCENY[ww][j],
+                             STARCENX[ww][j],
+                             STARCENY[ww][j],
                              RA_REF[ww][j],
                              DEC_REF[ww][j],
                              ROLL_REF[ww][j] - V3I_YANG[ww][j] * VPARITY[ww][j],
@@ -649,6 +674,10 @@ class Database():
         BUNIT = []
         CRPIX1 = []  # pix
         CRPIX2 = []  # pix
+        MASKCENX = [] # pix
+        MASKCENY = [] # pix
+        STARCENX = [] # pix
+        STARCENY = [] # pix
         BLURFWHM = []  # pix
         HASH = []
         Ndatapaths = len(datapaths)
@@ -746,6 +775,10 @@ class Database():
             else:
                 CRPIX1 += [head.get('CRPIX1', np.nan)]
                 CRPIX2 += [head.get('CRPIX2', np.nan)]
+            MASKCENX += [head.get('MASKCENX', CRPIX1[i])]
+            MASKCENY += [head.get('MASKCENY', CRPIX2[i])]
+            STARCENX += [head.get('STARCENX', np.nan)]
+            STARCENY += [head.get('STARCENY', np.nan)]
             HASH += [TELESCOP[-1] + '_' + INSTRUME[-1] + '_' + DETECTOR[-1] + '_' + FILTER[-1] + '_' + PUPIL[-1] + '_' + CORONMSK[-1] + '_' + SUBARRAY[-1]]
             hdul.close()
         TYPE = np.array(TYPE)
@@ -777,6 +810,10 @@ class Database():
         BUNIT = np.array(BUNIT)
         CRPIX1 = np.array(CRPIX1)
         CRPIX2 = np.array(CRPIX2)
+        MASKCENX = np.array(MASKCENX)
+        MASKCENY = np.array(MASKCENY)
+        STARCENX = np.array(STARCENX)
+        STARCENY = np.array(STARCENY)
         BLURFWHM = np.array(BLURFWHM)
         HASH = np.array(HASH)
         
@@ -812,6 +849,8 @@ class Database():
                                    'PPS_APER',
                                    'PIXSCALE',
                                    'PIXAR_SR',
+                                   'STARCENX',
+                                   'STARCENY',
                                    'MODE',
                                    'ANNULI',
                                    'SUBSECTS',
@@ -840,6 +879,8 @@ class Database():
                                    'object',
                                    'object',
                                    'object',
+                                   'float',
+                                   'float',
                                    'float',
                                    'float',
                                    'object',
@@ -878,6 +919,8 @@ class Database():
                              PPS_APER[ww[j]],
                              PIXSCALE[ww[j]],
                              PIXAR_SR[ww[j]],
+                             STARCENX[ww[j]],
+                             STARCENY[ww[j]],
                              MODE[ww[j]],
                              ANNULI[ww[j]],
                              SUBSECTS[ww[j]],
@@ -1037,10 +1080,10 @@ class Database():
             print_tab = copy.deepcopy(self.obs[key])
             if include_fitsfiles:
                 print_tab.remove_columns(['TARG_RA', 'TARG_DEC', 'EXPSTART', 'APERNAME', 'PPS_APER', 
-                                          'CRPIX1', 'CRPIX2', 'RA_REF', 'DEC_REF'])
+                                          'CRPIX1', 'CRPIX2','MASKCENX','MASKCENY','STARCENX','STARCENY', 'RA_REF', 'DEC_REF'])
             else:
                 print_tab.remove_columns(['TARG_RA', 'TARG_DEC', 'EXPSTART', 'APERNAME', 'PPS_APER', 
-                                          'CRPIX1', 'CRPIX2', 'RA_REF', 'DEC_REF', 'FITSFILE', 'MASKFILE'])
+                                          'CRPIX1', 'CRPIX2','MASKCENX','MASKCENY','STARCENX','STARCENY', 'RA_REF', 'DEC_REF', 'FITSFILE', 'MASKFILE'])
             print_tab['XOFFSET'] *= 1e3
             print_tab['XOFFSET'] = np.round(print_tab['XOFFSET'])
             print_tab['XOFFSET'][print_tab['XOFFSET'] == 0.] = 0.
@@ -1124,6 +1167,10 @@ class Database():
                    yoffset=None,
                    crpix1=None,
                    crpix2=None,
+                   maskcenx=None,
+                   maskceny=None,
+                   starcenx=None,
+                   starceny=None,
                    blurfwhm=None,
                    update_pxar=False):
         """
@@ -1195,6 +1242,14 @@ class Database():
             self.obs[key]['CRPIX1'][index] = crpix1
         if crpix2 is not None:
             self.obs[key]['CRPIX2'][index] = crpix2
+        if maskcenx is not None:
+            self.obs[key]['MASKCENX'][index] = maskcenx
+        if maskceny is not None:
+            self.obs[key]['MASKCENY'][index] = maskceny
+        if starcenx is not None:
+            self.obs[key]['STARCENX'][index] = starcenx
+        if starceny is not None:
+            self.obs[key]['STARCENY'][index] = starceny
         if blurfwhm is not None:
             self.obs[key]['BLURFWHM'][index] = blurfwhm
         self.obs[key]['FITSFILE'][index] = fitsfile

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -3292,14 +3292,12 @@ class ImageTools():
                     # frame.
                     if align_to_file is not None or j != ww_sci[0] or k != 0:
                         # Calculate shifts relative to first frame, work in pixels
-                        xfirst = starcenx + (xoffset/pxsc)
-                        xoff_curr_pix = self.database.obs[key]['XOFFSET'][j]/self.database.obs[key]['PIXSCALE'][j]
-                        xcurrent = self.database.obs[key]['STARCENX'][j] + xoff_curr_pix
+                        xfirst = starcenx
+                        xcurrent = self.database.obs[key]['STARCENX'][j]
                         xshift = xfirst - xcurrent
 
-                        yfirst = starceny + (yoffset/pxsc)
-                        yoff_curr_pix = self.database.obs[key]['YOFFSET'][j]/self.database.obs[key]['PIXSCALE'][j]
-                        ycurrent = self.database.obs[key]['STARCENY'][j] + yoff_curr_pix
+                        yfirst = starceny
+                        ycurrent = self.database.obs[key]['STARCENY'][j] 
                         yshift = yfirst - ycurrent
 
                         # Get mask center to also register the shift in its location

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -300,8 +300,8 @@ class ImageTools():
                     pxdq = pxdq[:, npix[2]:-npix[3], npix[0]:-npix[1]]
                     if mask is not None:
                         mask = mask[npix[2]:-npix[3], npix[0]:-npix[1]]
-                    # crpix1 -= npix[0]
-                    # crpix2 -= npix[2]
+                    crpix1 -= npix[0]
+                    crpix2 -= npix[2]
                     starcenx -= npix[0]
                     starceny -= npix[2]
                     maskcenx -= npix[0]
@@ -309,8 +309,8 @@ class ImageTools():
                     log.info('  --> Frame cropping: old shape = ' + str(sh[1:]) + ', new shape = ' + str(data.shape[1:]))
 
                 # Write FITS file and PSF mask.
-                # head_sci['CRPIX1'] = crpix1
-                # head_sci['CRPIX2'] = crpix2
+                head_sci['CRPIX1'] = crpix1
+                head_sci['CRPIX2'] = crpix2
                 head_sci['STARCENX'] = starcenx
                 head_sci['STARCENY'] = starceny
                 head_sci['MASKCENX'] = maskcenx
@@ -396,8 +396,8 @@ class ImageTools():
                     pxdq = np.pad(pxdq, ((0, 0), (npix[2], npix[3]), (npix[0], npix[1])), mode='constant', constant_values=0)
                     if mask is not None:
                         mask = np.pad(mask, ((npix[2], npix[3]), (npix[0], npix[1])), mode='constant', constant_values=np.nan)
-                    # crpix1 += npix[0]
-                    # crpix2 += npix[2]
+                    crpix1 += npix[0]
+                    crpix2 += npix[2]
                     starcenx += npix[0]
                     starceny += npix[2]
                     maskcenx += npix[0]
@@ -405,8 +405,8 @@ class ImageTools():
                     log.info('  --> Frame padding: old shape = ' + str(sh[1:]) + ', new shape = ' + str(data.shape[1:]) + ', fill value = %.2f' % cval)
 
                 # Write FITS file and PSF mask.
-                # head_sci['CRPIX1'] = crpix1
-                # head_sci['CRPIX2'] = crpix2
+                head_sci['CRPIX1'] = crpix1
+                head_sci['CRPIX2'] = crpix2
                 head_sci['STARCENX'] = starcenx
                 head_sci['STARCENY'] = starceny
                 head_sci['MASKCENX'] = maskcenx

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -283,6 +283,10 @@ class ImageTools():
                 mask = ut.read_msk(maskfile)
                 crpix1 = self.database.obs[key]['CRPIX1'][j]
                 crpix2 = self.database.obs[key]['CRPIX2'][j]
+                starcenx = self.database.obs[key]['STARCENX'][j]
+                starceny = self.database.obs[key]['STARCENY'][j]
+                maskcenx = self.database.obs[key]['MASKCENX'][j]
+                maskceny = self.database.obs[key]['MASKCENY'][j]
 
                 # Skip file types that are not in the list of types.
                 if self.database.obs[key]['TYPE'][j] in types:
@@ -296,18 +300,26 @@ class ImageTools():
                     pxdq = pxdq[:, npix[2]:-npix[3], npix[0]:-npix[1]]
                     if mask is not None:
                         mask = mask[npix[2]:-npix[3], npix[0]:-npix[1]]
-                    crpix1 -= npix[0]
-                    crpix2 -= npix[2]
+                    # crpix1 -= npix[0]
+                    # crpix2 -= npix[2]
+                    starcenx -= npix[0]
+                    starceny -= npix[2]
+                    maskcenx -= npix[0]
+                    maskceny -= npix[2]
                     log.info('  --> Frame cropping: old shape = ' + str(sh[1:]) + ', new shape = ' + str(data.shape[1:]))
 
                 # Write FITS file and PSF mask.
-                head_sci['CRPIX1'] = crpix1
-                head_sci['CRPIX2'] = crpix2
+                # head_sci['CRPIX1'] = crpix1
+                # head_sci['CRPIX2'] = crpix2
+                head_sci['STARCENX'] = starcenx
+                head_sci['STARCENY'] = starceny
+                head_sci['MASKCENX'] = maskcenx
+                head_sci['MASKCENY'] = maskceny
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
-                self.database.update_obs(key, j, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2,starcenx=starcenx, starceny=starceny,maskcenx=maskcenx, maskceny=maskceny)
 
         pass
 
@@ -367,6 +379,10 @@ class ImageTools():
                 mask = ut.read_msk(maskfile)
                 crpix1 = self.database.obs[key]['CRPIX1'][j]
                 crpix2 = self.database.obs[key]['CRPIX2'][j]
+                starcenx = self.database.obs[key]['STARCENX'][j]
+                starceny = self.database.obs[key]['STARCENY'][j]
+                maskcenx = self.database.obs[key]['MASKCENX'][j]
+                maskceny = self.database.obs[key]['MASKCENY'][j]
 
                 # Skip file types that are not in the list of types.
                 if self.database.obs[key]['TYPE'][j] in types:
@@ -380,18 +396,26 @@ class ImageTools():
                     pxdq = np.pad(pxdq, ((0, 0), (npix[2], npix[3]), (npix[0], npix[1])), mode='constant', constant_values=0)
                     if mask is not None:
                         mask = np.pad(mask, ((npix[2], npix[3]), (npix[0], npix[1])), mode='constant', constant_values=np.nan)
-                    crpix1 += npix[0]
-                    crpix2 += npix[2]
+                    # crpix1 += npix[0]
+                    # crpix2 += npix[2]
+                    starcenx += npix[0]
+                    starceny += npix[2]
+                    maskcenx += npix[0]
+                    maskceny += npix[2]
                     log.info('  --> Frame padding: old shape = ' + str(sh[1:]) + ', new shape = ' + str(data.shape[1:]) + ', fill value = %.2f' % cval)
 
                 # Write FITS file and PSF mask.
-                head_sci['CRPIX1'] = crpix1
-                head_sci['CRPIX2'] = crpix2
+                # head_sci['CRPIX1'] = crpix1
+                # head_sci['CRPIX2'] = crpix2
+                head_sci['STARCENX'] = starcenx
+                head_sci['STARCENY'] = starceny
+                head_sci['MASKCENX'] = maskcenx
+                head_sci['MASKCENY'] = maskceny
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
-                self.database.update_obs(key, j, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2,starcenx=starcenx, starceny=starceny,maskcenx=maskcenx, maskceny=maskceny)
 
         pass
 
@@ -2390,11 +2414,19 @@ class ImageTools():
                 mask = ut.read_msk(maskfile)
                 crpix1 = self.database.obs[key]['CRPIX1'][ww]
                 crpix2 = self.database.obs[key]['CRPIX2'][ww]
+                maskcenx = self.database.obs[key]['MASKCENX'][ww]
+                maskceny = self.database.obs[key]['MASKCENY'][ww]
+                starcenx = self.database.obs[key]['STARCENX'][ww]
+                starceny = self.database.obs[key]['STARCENY'][ww]
                 head, tail = os.path.split(fitsfile)
 
                 # Write FITS file and PSF mask.
                 head_sci['CRPIX1'] = crpix1
                 head_sci['CRPIX2'] = crpix2
+                head_sci['MASKCENX'] = maskcenx
+                head_sci['MASKCENY'] = maskceny
+                head_sci['STARCENX'] = starcenx
+                head_sci['STARCENY'] = starceny
 
                 # Inject only into SCI type data
                 if ww_type[ww] == 'SCI':
@@ -2559,7 +2591,7 @@ class ImageTools():
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
-                self.database.update_obs(key,ww, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key,ww, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2,starcenx=starcenx, starceny=starceny,maskcenx=maskcenx, maskceny=maskceny)
 
     def update_nircam_centers(self,
                               force_siaf_center=False, 
@@ -2626,14 +2658,14 @@ class ImageTools():
                     # newer or if force_siaf_center unless force_db_center.
                     if (not force_db_center) and ((np.searchsorted(prds, file_prd_ver) < np.searchsorted(prds, pysiaf.JWST_PRD_VERSION)) 
                         or force_siaf_center):
-                        log.info('  --> Update NIRCam coronagraphy centers: using CRPIX from pysiaf')
+                        log.info('  --> Update NIRCam coronagraphy centers: using MASKCEN from pysiaf')
                         apsiaf = siaf[self.database.obs[key]['APERNAME'][j]]
-                        crpix1 = apsiaf.XSciRef
-                        crpix2 = apsiaf.YSciRef
+                        maskcenx = apsiaf.XSciRef
+                        maskceny = apsiaf.YSciRef
                     else:
-                        log.info('  --> Update NIRCam coronagraphy centers: using CRPIX from database')
-                        crpix1 = self.database.obs[key]['CRPIX1'][j]
-                        crpix2 = self.database.obs[key]['CRPIX2'][j]
+                        log.info('  --> Update NIRCam coronagraphy centers: using MASKCEN from database')
+                        maskcenx = self.database.obs[key]['MASKCENX'][j]
+                        maskceny = self.database.obs[key]['MASKCENY'][j]
 
                     # Get filter shift from Jarron.
                     try:
@@ -2643,12 +2675,13 @@ class ImageTools():
                         xshift_jarron, yshift_jarron = 0., 0.
 
                     xoff, yoff = xshift_jarron, yshift_jarron
-                    log.info('  --> Update NIRCam coronagraphy centers: old = (%.2f, %.2f), new = (%.2f, %.2f)' % (crpix1, crpix2, crpix1 + xoff, crpix2 + yoff))
-                    crpix1 += xoff
-                    crpix2 += yoff
+                    log.info('  --> Update NIRCam coronagraphy centers: old = (%.2f, %.2f), new = (%.2f, %.2f)' % (maskcenx, maskceny, maskcenx + xoff, maskceny + yoff))
+                    maskcenx += xoff
+                    maskceny += yoff
 
                     # Update spaceKLIP database.
-                    self.database.update_obs(key, j, fitsfile, maskfile, crpix1=crpix1, crpix2=crpix2)
+                    # Change also CRPIX to be the same as maskcen
+                    self.database.update_obs(key, j, fitsfile, maskfile, crpix1=maskcenx, crpix2=maskceny, maskcenx=maskcenx, maskceny=maskceny)
 
         pass
 
@@ -2704,7 +2737,7 @@ class ImageTools():
         """
 
         # Update NIRCam coronagraphy centers, i.e., change SIAF CRPIX position
-        # to true mask center determined by Jarron.
+        # to true mask center determined by Jarron 
         # self.update_nircam_centers()  # shall be run purposely by the user
 
         # Set output directory.
@@ -2774,8 +2807,13 @@ class ImageTools():
                             mask = spline_shift(mask, [shifts[k][1], shifts[k][0]], order=0, mode='constant', cval=np.nanmedian(mask))
                         xoffset = self.database.obs[key]['XOFFSET'][j] - self.database.obs[key]['XOFFSET'][ww_sci[0]]  # arcsec
                         yoffset = self.database.obs[key]['YOFFSET'][j] - self.database.obs[key]['YOFFSET'][ww_sci[0]]  # arcsec
-                        crpix1 = (data.shape[-1] - 1.) / 2. + 1.  # 1-indexed
-                        crpix2 = (data.shape[-2] - 1.) / 2. + 1.  # 1-indexed
+                        # Update star center
+                        starcenx = (data.shape[-1] - 1.) / 2. + 1.  # 1-indexed
+                        starceny = (data.shape[-2] - 1.) / 2. + 1.  # 1-indexed
+
+                        # Update mask center (using the shift of the first frame)
+                        maskcenx = starcenx -xshift  # 1-indexed
+                        maskceny = starceny -yshift  # 1-indexed
                     
                     # MIRI coronagraphy.
                     elif self.database.obs[key]['EXP_TYPE'][j] in ['MIR_4QPM', 'MIR_LYOT']:
@@ -2787,8 +2825,13 @@ class ImageTools():
                             maskoffs_temp += [np.array([0., 0.])]
                         xoffset = self.database.obs[key]['XOFFSET'][j]  # arcsec
                         yoffset = self.database.obs[key]['YOFFSET'][j]  # arcsec
-                        crpix1 = self.database.obs[key]['CRPIX1'][j]  # 1-indexed
-                        crpix2 = self.database.obs[key]['CRPIX2'][j]  # 1-indexed
+
+                        # Star center and mask center stay the same
+                        starcenx = self.database.obs[key]['STARCENX'][j]  # 1-indexed
+                        starceny = self.database.obs[key]['STARCENY'][j]  # 1-indexed
+
+                        maskcenx = self.database.obs[key]['MASKCENX'][j]  # 1-indexed
+                        maskceny = self.database.obs[key]['MASKCENY'][j]  # 1-indexed
 
                     # Other data types.
                     else:
@@ -2818,8 +2861,13 @@ class ImageTools():
                                 erro[k] = np.roll(np.roll(erro[k], dx, axis=1), dy, axis=0)
                         xoffset = 0.  # arcsec
                         yoffset = 0.  # arcsec
-                        crpix1 = data.shape[-1]//2 + 1  # 1-indexed
-                        crpix2 = data.shape[-2]//2 + 1  # 1-indexed
+
+                        # Update star center
+                        starcenx = data.shape[-1]//2 + 1  # 1-indexed
+                        starceny = data.shape[-2]//2 + 1  # 1-indexed
+
+                        maskcenx = None
+                        maskceny = None
 
                 # TA data.
                 if j in ww_sci_ta or j in ww_ref_ta:
@@ -2849,8 +2897,13 @@ class ImageTools():
                             erro[k] = np.roll(np.roll(erro[k], dx, axis=1), dy, axis=0)
                     xoffset = 0.  # arcsec
                     yoffset = 0.  # arcsec
-                    crpix1 = data.shape[-1]//2 + 1  # 1-indexed
-                    crpix2 = data.shape[-2]//2 + 1  # 1-indexed
+                    
+                    starcenx = data.shape[-1]//2 + 1  # 1-indexed
+                    starceny = data.shape[-2]//2 + 1  # 1-indexed
+
+                    maskcenx = None
+                    maskceny = None
+
                 shifts = np.array(shifts)
                 shifts_all += [shifts]
                 maskoffs_temp = np.array(maskoffs_temp)
@@ -2873,13 +2926,16 @@ class ImageTools():
                 # Write FITS file and PSF mask.
                 head_pri['XOFFSET'] = xoffset #arcsec
                 head_pri['YOFFSET'] = yoffset #arcsec
-                head_sci['CRPIX1'] = crpix1
-                head_sci['CRPIX2'] = crpix2
+                head_sci['STARCENX'] = starcenx
+                head_sci['STARCENY'] = starceny
+                if maskcenx is not None:
+                    head_sci['MASKCENX'] = maskcenx
+                    head_sci['MASKCENY'] = maskceny
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
-                self.database.update_obs(key, j, fitsfile, maskfile, xoffset=xoffset, yoffset=yoffset, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, maskfile, xoffset=xoffset, yoffset=yoffset, starcenx=starcenx, starceny=starceny,maskcenx=maskcenx, maskceny=maskceny)
 
         pass
 
@@ -2946,8 +3002,8 @@ class ImageTools():
         spectrum = webbpsf_ext.stellar_spectrum(spectral_type)
 
         # Get true mask center.
-        crpix1 = self.database.obs[key]['CRPIX1'][j] - 1  # 0-indexed
-        crpix2 = self.database.obs[key]['CRPIX2'][j] - 1  # 0-indexed
+        maskcenx = self.database.obs[key]['MASKCENX'][j] - 1  # 0-indexed
+        maskceny = self.database.obs[key]['MASKCENY'][j] - 1  # 0-indexed
 
         # Initialize JWST_PSF object. Use odd image size so that PSF is
         # centered in pixel center.
@@ -2969,8 +3025,8 @@ class ImageTools():
 
         # Generate model PSF. Apply offset between SIAF reference pixel
         # position and true mask center.
-        xoff = (crpix1 + 1) - xsciref
-        yoff = (crpix2 + 1) - ysciref
+        xoff = (maskcenx + 1) - xsciref
+        yoff = (maskceny + 1) - ysciref
         model_psf = psf.gen_psf_idl((0, 0), coord_frame='idl', return_oversample=False, quick=True)
         if not isinstance(highpass, bool):
             highpass = float(highpass)
@@ -2994,7 +3050,7 @@ class ImageTools():
 
             # Determine relative shift between data and model PSF. Iterate 3 times
             # to improve precision.
-            xc, yc = (crpix1, crpix2)
+            xc, yc = (maskcenx, maskceny) # start assuming that star is exactly at the center of the coronagraph
             for i in range(3):
 
                 # Crop data and transmission mask.
@@ -3023,7 +3079,7 @@ class ImageTools():
                 # Update star position.
                 xc = np.mean(xsub_indarr) + xshift
                 yc = np.mean(ysub_indarr) + yshift
-            xshift, yshift = (xc - crpix1, yc - crpix2)
+            xshift, yshift = (xc - maskcenx, yc - maskceny)
             shift_list.append([xshift, yshift])
             log.info('  --> Recenter frames: star offset between frame %i and coronagraph center (dx, dy) = (%.3f, %.3f) pix' % (count,xshift, yshift))
             count+=1
@@ -3043,7 +3099,7 @@ class ImageTools():
             ax[1].contourf(masksub, levels=[0.00, 0.25, 0.50, 0.75], cmap='Greys_r', vmin=0., vmax=2., alpha=0.5)
             ax[1].set_title('Model PSF & transmission mask')
             ax[2].scatter((xsciref), (ysciref), marker='+', color='black', label='SIAF reference point')
-            ax[2].scatter((crpix1 + 1), (crpix2 + 1), marker='x', color='skyblue', label='True mask center')
+            ax[2].scatter((maskcenx + 1), (maskceny + 1), marker='x', color='skyblue', label='True mask center')
             ax[2].scatter((xc + 1), (yc + 1), marker='*', color='red', label='Computed star position')
             ax[2].set_aspect('equal')
             xlim = ax[2].get_xlim()
@@ -3218,6 +3274,7 @@ class ImageTools():
                 if np.sum(np.isnan(data)) != 0:
                     raise UserWarning('Please replace nan pixels before attempting to align frames')
                 shifts = []
+                maskcen = []
                 for k in range(data.shape[0]):
 
                     # Take the first science frame as reference frame.
@@ -3227,23 +3284,29 @@ class ImageTools():
                         pp = np.array([0., 0., 1.])
                         xoffset = self.database.obs[key]['XOFFSET'][j] #arcsec
                         yoffset = self.database.obs[key]['YOFFSET'][j] #arcsec
-                        crpix1 = self.database.obs[key]['CRPIX1'][j] #pixels
-                        crpix2 = self.database.obs[key]['CRPIX2'][j] #pixels
+                        starcenx = self.database.obs[key]['STARCENX'][j] #pixels
+                        starceny = self.database.obs[key]['STARCENY'][j] #pixels
                         pxsc = self.database.obs[key]['PIXSCALE'][j] #arcsec
 
                     # Align all other SCI and REF frames to the first science
                     # frame.
                     if align_to_file is not None or j != ww_sci[0] or k != 0:
                         # Calculate shifts relative to first frame, work in pixels
-                        xfirst = crpix1 + (xoffset/pxsc)
+                        xfirst = starcenx + (xoffset/pxsc)
                         xoff_curr_pix = self.database.obs[key]['XOFFSET'][j]/self.database.obs[key]['PIXSCALE'][j]
-                        xcurrent = self.database.obs[key]['CRPIX1'][j] + xoff_curr_pix
+                        xcurrent = self.database.obs[key]['STARCENX'][j] + xoff_curr_pix
                         xshift = xfirst - xcurrent
 
-                        yfirst = crpix2 + (yoffset/pxsc)
+                        yfirst = starceny + (yoffset/pxsc)
                         yoff_curr_pix = self.database.obs[key]['YOFFSET'][j]/self.database.obs[key]['PIXSCALE'][j]
-                        ycurrent = self.database.obs[key]['CRPIX2'][j] + yoff_curr_pix
+                        ycurrent = self.database.obs[key]['STARCENY'][j] + yoff_curr_pix
                         yshift = yfirst - ycurrent
+
+                        # Get mask center to also register the shift in its location
+                        maskcenx = self.database.obs[key]['MASKCENX'][j] #pixels
+                        maskceny = self.database.obs[key]['MASKCENY'][j] #pixels
+
+                        maskcen += [np.array([maskcenx, maskceny])]
 
                         if scale_prior:
                             ww = mask < 0.5
@@ -3286,6 +3349,7 @@ class ImageTools():
                         data[k] = ut.imshift(data[k], [shifts[k][0], shifts[k][1]], method=method, kwargs=kwargs)
                         erro[k] = ut.imshift(erro[k], [shifts[k][0], shifts[k][1]], method=method, kwargs=kwargs)
                 shifts = np.array(shifts)
+                maskcen = np.array(maskcen)
                 if mask is not None:
                     if align_to_file is not None or j != ww_sci[0]:
                         temp = np.median(shifts, axis=0)
@@ -3320,13 +3384,18 @@ class ImageTools():
                 # Write FITS file and PSF mask.
                 head_pri['XOFFSET'] = xoffset #arcseconds
                 head_pri['YOFFSET'] = yoffset #arcseconds
-                head_sci['CRPIX1'] = crpix1
-                head_sci['CRPIX2'] = crpix2
+                head_sci['STARCENX'] = starcenx
+                head_sci['STARCENY'] = starceny
+                # Change mask location too: take first values of the shifts of the current fits file for now
+                maskcenx = maskcen[0,0] + shifts[0,0]
+                maskceny = maskcen[0,1] + shifts[0,1]
+                head_sci['MASKCENX'] = maskcenx
+                head_sci['MASKCENY'] = maskceny
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
-                self.database.update_obs(key, j, fitsfile, maskfile, xoffset=xoffset, yoffset=yoffset, crpix1=crpix1, crpix2=crpix2)
+                self.database.update_obs(key, j, fitsfile, maskfile, xoffset=xoffset, yoffset=yoffset, starcenx=starcenx, starceny=starceny,maskcenx=maskcenx, maskceny=maskceny)
 
             # Plot science frame alignment.
             colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
@@ -3625,7 +3694,7 @@ class ImageTools():
 
             files = db_tab['FITSFILE']
 
-            c_star = np.array([db_tab['CRPIX1'][0], db_tab['CRPIX2'][0]])-1
+            c_star = np.array([db_tab['STARCENX'][0], db_tab['STARCENY'][0]])-1
 
             h1 = fits.getheader(files[0], ext=1)
             ny, nx = h1['NAXIS2'], h1['NAXIS1']

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -2404,7 +2404,8 @@ class ImageTools():
             log.info('--> Concatenation ' + key)
             #######################################################################################################################
             filepaths, psflib_filepaths = get_pyklip_filepaths(self.database, key)
-            raw_dataset = JWSTData(filepaths, psflib_filepaths)
+            raw_dataset = JWSTData(filepaths, psflib_filepaths,
+                                   center_keywords=['STARCENX','STARCENY'])
 
             for ww in range(len(ww_type)):
                 # Read input files and store values that we just want to save in the output_dir

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -264,7 +264,8 @@ def display_coron_image(filename,
         # PyKLIP output, we have to open this differently, can't use JWST datamodels.
         image = fits.getdata(filename)
         header = fits.getheader(filename)
-        center_x, center_y = header['CRPIX1'], header['CRPIX2']
+        #display(header)
+        center_x, center_y = header['STARCENX'], header['STARCENY']
         bunit = header['BUNIT']
         wcs = astropy.wcs.WCS(header)
         if image.ndim == 3:
@@ -275,12 +276,16 @@ def display_coron_image(filename,
     else:
         # Handle JWST pipeline outputs.
         # Load in JWST pipeline outputs using jwst.datamodel.
+        header = fits.open(filename)[1].header
+        #display(header)
         modeltype = jwst.datamodels.CubeModel if cube_ints else jwst.datamodels.ImageModel
         model = modeltype(filename)
         image = np.nanmean(model.data, axis=0) if cube_ints else model.data
         dq = model.dq[0] if cube_ints else model.dq
         nints = model.meta.exposure.nints if cube_ints else None
-        center_x, center_y = model.meta.wcsinfo.crpix1, model.meta.wcsinfo.crpix2
+        #center_x, center_y = model.meta.wcsinfo.crpix1, model.meta.wcsinfo.crpix2
+        center_x, center_y = header['STARCENX'], header['STARCENY']
+        
         bunit = model.meta.bunit_data
         is_psf = model.meta.exposure.psf_reference
         annotation_text = (

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -265,7 +265,7 @@ def display_coron_image(filename,
         image = fits.getdata(filename)
         header = fits.getheader(filename)
         #display(header)
-        center_x, center_y = header['STARCENX'], header['STARCENY']
+        center_x, center_y = header['CRPIX1'], header['CRPIX2']
         bunit = header['BUNIT']
         wcs = astropy.wcs.WCS(header)
         if image.ndim == 3:

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -1048,11 +1048,17 @@ def plot_subimages(imgdirs, subdirs, filts, submodes, numKL,
 
         # get center information
         if instrument == 'NIRCAM':
-            center_pix = (int(np.rint(hdr['CRPIX2']-1)), 
-                          int(np.rint(hdr['CRPIX1']-1)))
+            center_pix = (int(np.rint(hdr.get('STARCENY', hdr['MASKCENY'])-1)),
+                          int(np.rint(hdr.get('STARCENX', hdr['MASKCENX'])-1)),
+                          )
+            # center_pix = (int(np.rint(hdr['STARCENY']-1)), 
+            #              int(np.rint(hdr['STARCENX']-1)))
             window_pix = int(np.rint(window_size / pltscale['NIRCAM'] / 2))
             offset = (window_pix - window_size / 0.063 / 2) *0.063
         else:
+            # center_pix = (int(np.rint(hdr.get('STARCENY', hdr['MASKCENY'])-1)),
+            #               int(np.rint(hdr.get('STARCENX', hdr['MASKCENX'])-1)),
+            #               ) # potential replacement!
             center_pix = miri_img_centers[flt]
             window_pix = int(np.rint(window_size / pltscale['MIRI'] / 2))
             offset = (window_pix - window_size / 0.11 / 2) *0.11

--- a/spaceKLIP/psf.py
+++ b/spaceKLIP/psf.py
@@ -863,7 +863,7 @@ def get_transmission(obs):
         mask = hdul['SCI'].data
         hdul.close()
         totint = obs['NINTS'][j] * obs['EFFINTTM'][j]  # s
-        center = [obs['CRPIX1'][j] - 1., obs['CRPIX2'][j] - 1.]  # pix (0-indexed)
+        center = [obs['MASKCENX'][j] - 1., obs['MASKCENY'][j] - 1.]  # pix (0-indexed)
         new_center = [mask.shape[1] // 2, mask.shape[0] // 2]  # pix (0-indexed)
         totmsk += [totint * nanrotate(mask.copy(), obs['ROLL_REF'][j], center=center, new_center=new_center)]
         totexp += totint  # s

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -135,21 +135,11 @@ def run_obs(database,
             
             # Initialize pyKLIP dataset.
             pop_pxar_kw(np.append(filepaths, psflib_filepaths))
-            dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'],center_include_offset=False)
+            dataset = JWSTData(filepaths, psflib_filepaths, 
+                               highpass=kwargs_temp['highpass'],
+                               center_include_offset=False,
+                               center_keywords=['STARCENX','STARCENY'])
             kwargs_temp['dataset'] = dataset
-
-            ## THIS DIDN'T FIX IT ANYWAY
-            # TEMPORARY FIX: Overwrite centers with new header vals
-            # Ideally we should modify pyklip.instruments.JWST.py 
-            # to reference 'STARCENX/Y' instead of 'CRPIX1/2'
-            # sci_centers = []
-            # for row in database.obs[key]:
-            #     if row['TYPE'] == 'SCI':
-            #         centers = [[row['STARCENX']-1,row['STARCENY']-1]] * row['NINTS']
-            #         sci_centers.extend(centers)
-            # sci_centers = np.array(sci_centers)
-            # dataset.centers = sci_centers
-            # dataset.psflib.aligned_center = dataset.centers[0]
             kwargs_temp['aligned_center'] = dataset.psflib.aligned_center
             kwargs_temp['psf_library'] = dataset.psflib
             kwargs_temp['mode'] = mode
@@ -208,6 +198,8 @@ def run_obs(database,
                     w = wcs.WCS(head_sci)
                     _rotate_wcs_hdr(w, database.obs[key]['ROLL_REF'][ww_sci[0]])
                     hdul[0].header['WCSAXES'] = head_sci['WCSAXES']
+                    hdul[0].header['CRPIX1'] = head_sci['STARCENX']
+                    hdul[0].header['CRPIX2'] = head_sci['STARCENY']
                     hdul[0].header['CRVAL1'] = head_sci['CRVAL1']
                     hdul[0].header['CRVAL2'] = head_sci['CRVAL2']
                     hdul[0].header['CTYPE1'] = head_sci['CTYPE1']
@@ -237,6 +229,8 @@ def run_obs(database,
                                 hdul[0].data = np.nanmedian(dataset.allints[:, :, ww, :, :], axis=2)
                             hdul[0].header['NINTS'] = database.obs[key]['NINTS'][j]
                             hdul[0].header['WCSAXES'] = head_sci['WCSAXES']
+                            hdul[0].header['CRPIX1'] = head_sci['STARCENX']
+                            hdul[0].header['CRPIX2'] = head_sci['STARCENY']
                             hdul[0].header['CRVAL1'] = head_sci['CRVAL1']
                             hdul[0].header['CRVAL2'] = head_sci['CRVAL2']
                             hdul[0].header['CTYPE1'] = head_sci['CTYPE1']

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -137,13 +137,18 @@ def run_obs(database,
             pop_pxar_kw(np.append(filepaths, psflib_filepaths))
             dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'],center_include_offset=False)
             kwargs_temp['dataset'] = dataset
-            # Overwrite centers with new header vals
-            dataset.centers = [[row['STARCENX'],row['STARCENY']]*row['NINTS'] for row in database.obs[key]]
+
+            # TEMPORARY FIX: Overwrite centers with new header vals
+            # Ideally we should modify pyklip.instruments.JWST.py 
+            # to reference 'STARCENX/Y' instead of 'CRPIX1/2'
+            sci_centers = []
+            for row in database.obs[key]:
+                if row['TYPE'] == 'SCI':
+                    centers = [[row['STARCENX']-1,row['STARCENY']-1]] * row['NINTS']
+                    sci_centers.extend(centers)
+            sci_centers = np.array(sci_centers)
+            dataset.centers = sci_centers
             dataset.psflib.aligned_center = dataset.centers[0]
-            print('a')
-            print(dataset.centers)
-            print(dataset._centers)
-            print(dataset.psflib.aligned_center)
             kwargs_temp['aligned_center'] = dataset._centers[0]
             kwargs_temp['psf_library'] = dataset.psflib
             kwargs_temp['mode'] = mode

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -138,7 +138,12 @@ def run_obs(database,
             dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'],center_include_offset=False)
             kwargs_temp['dataset'] = dataset
             # Overwrite centers with new header vals
-            dataset.centers = [[database.obs[row]['STARCENX'],database.obs[row]['STARCENY']] for row in database.obs]
+            dataset.centers = [[row['STARCENX'],row['STARCENY']]*row['NINTS'] for row in database.obs[key]]
+            dataset.psflib.aligned_center = dataset.centers[0]
+            print('a')
+            print(dataset.centers)
+            print(dataset._centers)
+            print(dataset.psflib.aligned_center)
             kwargs_temp['aligned_center'] = dataset._centers[0]
             kwargs_temp['psf_library'] = dataset.psflib
             kwargs_temp['mode'] = mode

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -138,18 +138,19 @@ def run_obs(database,
             dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'],center_include_offset=False)
             kwargs_temp['dataset'] = dataset
 
+            ## THIS DIDN'T FIX IT ANYWAY
             # TEMPORARY FIX: Overwrite centers with new header vals
             # Ideally we should modify pyklip.instruments.JWST.py 
             # to reference 'STARCENX/Y' instead of 'CRPIX1/2'
-            sci_centers = []
-            for row in database.obs[key]:
-                if row['TYPE'] == 'SCI':
-                    centers = [[row['STARCENX']-1,row['STARCENY']-1]] * row['NINTS']
-                    sci_centers.extend(centers)
-            sci_centers = np.array(sci_centers)
-            dataset.centers = sci_centers
-            dataset.psflib.aligned_center = dataset.centers[0]
-            kwargs_temp['aligned_center'] = dataset._centers[0]
+            # sci_centers = []
+            # for row in database.obs[key]:
+            #     if row['TYPE'] == 'SCI':
+            #         centers = [[row['STARCENX']-1,row['STARCENY']-1]] * row['NINTS']
+            #         sci_centers.extend(centers)
+            # sci_centers = np.array(sci_centers)
+            # dataset.centers = sci_centers
+            # dataset.psflib.aligned_center = dataset.centers[0]
+            kwargs_temp['aligned_center'] = dataset.psflib.aligned_center
             kwargs_temp['psf_library'] = dataset.psflib
             kwargs_temp['mode'] = mode
             

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -135,8 +135,10 @@ def run_obs(database,
             
             # Initialize pyKLIP dataset.
             pop_pxar_kw(np.append(filepaths, psflib_filepaths))
-            dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'])
+            dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'],center_include_offset=False)
             kwargs_temp['dataset'] = dataset
+            # Overwrite centers with new header vals
+            dataset.centers = [[row['STARCENX'],row['STARCENY']] for row in database]
             kwargs_temp['aligned_center'] = dataset._centers[0]
             kwargs_temp['psf_library'] = dataset.psflib
             kwargs_temp['mode'] = mode

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -138,7 +138,7 @@ def run_obs(database,
             dataset = JWSTData(filepaths, psflib_filepaths, highpass=kwargs_temp['highpass'],center_include_offset=False)
             kwargs_temp['dataset'] = dataset
             # Overwrite centers with new header vals
-            dataset.centers = [[row['STARCENX'],row['STARCENY']] for row in database]
+            dataset.centers = [[database.obs[row]['STARCENX'],database.obs[row]['STARCENY']] for row in database.obs]
             kwargs_temp['aligned_center'] = dataset._centers[0]
             kwargs_temp['psf_library'] = dataset.psflib
             kwargs_temp['mode'] = mode


### PR DESCRIPTION
### PR Overview
Currently spaceKLIP tracks one pixel location `CRPIX1/2` and at different steps in the pipeline this can refer either to the location of the mask center or the star center. We add two additional header keywords (and associated table columns) to track the star location (`STARCENX/Y`) and the mask location (`MASKCENX/Y`). We have tested and confirmed the desired behavior on both NIRCam and MIRI ERS data.

*Note: This PR depends also on a PR to `pyklip` allowing the user to specify which header keyword to use as the star location for alignment and derotation purposes*

### Summary of changes to each file:

- `database.py `
  - Added `MASKCENX/Y` and `STARCENX/Y` keywords as columns to be tracked in the database. These are 1-indexed pixel locations analogous to the `CRPIX1/2` column. 
  - If not present in the input fits files, `STARCENX/Y` defaults to the `MASKCENX/Y` values, and `MASKCENX/Y` defaults to the `CRPIX1/2` values. 
- `imagetools.py`
  - Heaviest changes here, basically we choose on a case-by-case basis whether a given step should affect the star location, mask location, or `CRPIX`, or some combination.
  - In general, we only update `CRPIX` when the array is being shifted (i.e. padding, cropping, aligning). 
    - Right now we also update `CRPIX` during `recenter_frames()`, is this the right decision?
- `pyklippipeline.py`
  - Assuming pyklip PR goes through, we just need to add a keyword to the `pyklip.JWSTData` init to tell it to use the right keywords to decide where the center is (a.k.a. `STARCENX/Y`)
  - We also assign `CRPIX=STARCEN` at the end because I think pyKLIP redoes the WCS anyway.
- `analysistools.py`
  - Basically just changed all `CRPIX` to `STARCEN`, and added the `center_keywords` arg to calls to `pyklip.JWSTData`
- `plotting.py`
  - Same as above, except we fall back to `CRPIX` if `STARCEN` is missing from the header  (i.e. if we've just read in data straight from MAST). 
  - Also there's a weird bit in one of the plotting function that hardcodes the MIRI centers, maybe we should look at this line and see if it's still necessary.
- `psf.py`
  - Replaced `CRPIX` with `MASKCEN` in `get_transmission()`
