### PR TITLE
Updates for Python 3.12 and other minor fixes/improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scipy>=1.13.0
 stsci.stimage>=0.2.9
 stpsf>=2.0.0
 webbpsf_ext>=2.0.0
-pyklip>=2.7.1
+pyklip>=2.8.4
 ipywidgets>=8.1.5
 lmfit>1.2.2
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ astropy>=6.0.1
 astroquery>=0.4.7
 jwst>=1.14.0
 matplotlib>=3.7.1
-numpy<2
+numpy>=1.26.4
 synphot>=1.4.0
 stsynphot>=1.3.0
 scipy>=1.13.0
 stsci.stimage>=0.2.9
 stpsf>=2.0.0
-webbpsf_ext>=1.2.0
+webbpsf_ext>=2.0.0
 pyklip>=2.7.1
 ipywidgets>=8.1.5
 lmfit>1.2.2

--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -211,7 +211,7 @@ class AnalysisTools():
                 iwa = 1  # pix
                 owa = data.shape[1] // 2  # pix
                 if self.database.red[key]['TELESCOP'][j] == 'JWST':
-                    if self.database.red[key]['EXP_TYPE'][j] in ['NRC_CORON']:
+                    if self.database.red[key]['EXP_TYPE'][j] in ['NRC_CORON', 'NRC_TACONFIRM', 'NRC_TACQ']:
                         diam = 5.2
                     else:
                         diam = JWST_CIRCUMSCRIBED_DIAMETER
@@ -569,7 +569,7 @@ class AnalysisTools():
                 pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] # arcsec
                 pxsc_rad = pxsc_arcsec / 3600. / 180. * np.pi  # rad
                 if self.database.red[key]['TELESCOP'][j] == 'JWST':
-                    if self.database.red[key]['EXP_TYPE'][j] in ['NRC_CORON']:
+                    if self.database.red[key]['EXP_TYPE'][j] in ['NRC_CORON', 'NRC_TACONFIRM', 'NRC_TACQ']:
                         diam = 5.2
                     else:
                         diam = JWST_CIRCUMSCRIBED_DIAMETER

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -28,7 +28,6 @@ import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
-
 # =============================================================================
 # MAIN
 # =============================================================================
@@ -244,8 +243,6 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         save_results : bool, optional
             Save the JWST pipeline step product? None will default to the JWST
             pipeline step default. The default is None.
-        kwargs : keyword arguments
-            Default JWST pipeline step keyword arguments.
         
         Returns
         -------
@@ -253,6 +250,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             Output JWST datamodel.
         
         """
+
+        from .logging_tools import crds_logging_disabled
         
         # Determine if we're saving results for real
         if step_obj.skip:
@@ -274,7 +273,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         # Run step. Don't save results yet.
         step_save_orig = step_obj.save_results
         step_obj.save_results = False
-        res = step_obj.call(input)
+        with crds_logging_disabled():
+            res = step_obj.call(input)
         step_obj.save_results = step_save_orig
         
         # Check if group scale correction or gain scale correction were skipped.

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -283,7 +283,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         step_save_orig = step_obj.save_results
         step_obj.save_results = False
         with crds_logging_disabled():
-            res = step_obj.call(input)
+            res = step_obj.run(input)
         step_obj.save_results = step_save_orig
         
         # Check if group scale correction or gain scale correction were skipped.

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -123,8 +123,12 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         # Process MIR & NIR exposures differently.
         instrument = input.meta.instrument.name
         if instrument == 'MIRI':
+            # process MIRI exposures;
+            # the steps are in a different order than NIR
+            log.debug('Processing a MIRI exposure')
             input = self.run_step(self.group_scale, input)
             input = self.run_step(self.dq_init, input)
+            input = self.run_step(self.emicorr, input)
             input = self.run_step(self.saturation, input)
             #input = self.run_step(self.ipc, input) Not run for MIRI
             input = self.run_step(self.firstframe, input)
@@ -138,6 +142,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             input = self.run_step(self.jump, input)
             input = self.run_step(self.mask_groups, input)
         else:
+            # process Near-IR exposures
+            log.debug('Processing a Near-IR exposure')
             input = self.run_step(self.group_scale, input)
             input = self.run_step(self.dq_init, input)
             input = self.do_saturation(input)
@@ -145,7 +151,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             input = self.run_step(self.superbias, input)
             input = self.do_refpix(input)
             input = self.run_step(self.linearity, input)
-            input = self.run_step(self.persistence, input)
+            if instrument != 'NIRSPEC': 
+                input = self.run_step(self.persistence, input)
             input = self.run_step(self.dark_current, input)
             input = self.run_step(self.charge_migration, input)
             input = self.run_step(self.jump, input)
@@ -153,6 +160,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             #1overf Only present in NIR data
             if 'groups' in self.stage_1overf:
                 input = self.run_step(self.subtract_1overf, input)
+            # TODO: Test clean_flicker_noise step versus subtract_1overf
+            # input = self.clean_flicker_noise(input)
         
         # save the corrected ramp data, if requested
         if self.ramp_fit.save_calibrated_ramp or self.save_calibrated_ramp or self.save_intermediates:
@@ -169,18 +178,18 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
                 warnings.simplefilter('ignore', RuntimeWarning)
                 res = self.run_step(self.experimental_jumpramp, input)
                 rate, rateints = res
-        
-        if self.rate_int_outliers and rateints is not None:
+
+        if self.rate_int_outliers and (rateints is not None):
             # Flag additional outliers by comparing rateints and refit ramp
             input = self.apply_rateint_outliers(rateints, input)
             if input is None:
-                input, ints_model = rate, rateints
+                input, ints_model = (rate, rateints)
             else:
                 res = self.run_step(self.ramp_fit, input, save_results=False)
                 input, ints_model = (res, None) if self.ramp_fit.skip else res
         else:
             # input is the rate product, ints_model is the rateints product
-            input, ints_model = rate, rateints
+            input, ints_model = (rate, rateints)
 
         if input is None:
             self.ramp_fit.log.info('NoneType returned from ramp fitting. Gain scale correction skipped')

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -63,7 +63,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         
         Parameters
         ----------
-        \*\*kwargs : keyword arguments
+        kwargs : keyword arguments
             Default JWST stage 1 detector pipeline keyword arguments.
         
         Returns
@@ -244,7 +244,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         save_results : bool, optional
             Save the JWST pipeline step product? None will default to the JWST
             pipeline step default. The default is None.
-        \*\*kwargs : keyword arguments
+        kwargs : keyword arguments
             Default JWST pipeline step keyword arguments.
         
         Returns
@@ -306,7 +306,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         ----------
         input : jwst.datamodel
             Input JWST datamodel to be processed.
-        \*\*kwargs : keyword arguments
+        kwargs : keyword arguments
             Default JWST stage 1 saturation step keyword arguments.
         
         Returns
@@ -425,7 +425,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         ----------
         input : jwst.datamodel
             Input JWST datamodel to be processed.
-        \*\*kwargs : keyword arguments
+        kwargs : keyword arguments
             Default JWST stage 1 refpix step keyword arguments.
         
         Returns
@@ -465,7 +465,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         ----------
         input : jwst.datamodel
             Input JWST datamodel to be processed.
-        \*\*kwargs : keyword arguments
+        kwargs : keyword arguments
             Default JWST stage 1 refpix step keyword arguments.
         
         Returns

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -962,7 +962,7 @@ def run_obs(database,
                 steps['mask_groups']['skip'] = False
                 skip_revert = False
 
-            if (j == jtervals[-1]) and (groupmaskflag == 1):
+            if (j == nfitsfiles-1) and (groupmaskflag == 1):
                 '''This is the last file for this concatenation, and the groupmaskflag has been
                 set. This means we need to reset the mask_array back to original state, 
                 which was that it didn't exist, so that the routine is rerun. '''

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -166,8 +166,8 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     skip_resample : bool, optional
         Skip the resampling (drizzle) step? While the default is set
         to False, this step only applies to normal imaging modes and
-        skips coronagraphic observation. For coronagraphic observations,
-        resampling occurs in Stage 3.
+        only on rate/cal files (not rateints/calints). 
+        For coronagraphic observations, resampling occurs in Stage 3.
     skip_wcs : bool, optional
         Skip the WCS assignment step? The default is False.
     skip_flat : bool, optional
@@ -260,7 +260,9 @@ def run_obs(database,
         See here for how to use the steps parameter:
         https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
         Custom step parameters are:
+
         - n/a
+
         The default is {}.
     subdir : str, optional
         Name of the directory where the data products shall be saved. The
@@ -287,8 +289,8 @@ def run_obs(database,
     skip_resample : bool, optional
         Skip the resampling (drizzle) step? While the default is set
         to False, this step only applies to normal imaging modes and
-        skips coronagraphic observation. For coronagraphic observations,
-        resampling occurs in Stage 3.
+        only on rate/cal files (not rateints/calints). 
+        For coronagraphic observations, resampling occurs in Stage 3.
     skip_wcs : bool, optional
         Skip the WCS assignment step? The default is False.
     skip_flat : bool, optional

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -98,8 +98,9 @@ class Coron2Pipeline_spaceKLIP(Image2Pipeline):
             filebase = os.path.basename(asn.filename)
             res = self.process_exposure_product(product, asn['asn_pool'], filebase)
             
-            # Run outlier detection.
-            res = self.outlier_detection.run(res)
+            # Run outlier detection on CubeModel
+            if isinstance(res, datamodels.CubeModel):
+                res = self.outlier_detection.run(res)
             
             # Save results.
             suffix = 'calints' if isinstance(res, datamodels.CubeModel) else 'cal'

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -108,11 +108,15 @@ class Coron2Pipeline_spaceKLIP(Image2Pipeline):
             all_res.append(res)
 
             # If outlier detection was run but intermediates were not request
-            # to be saved, remove the intermediate _median.fits files.
+            # to be saved, remove the intermediate files.
             if not self.save_intermediates and not self.outlier_detection.skip:
                 file_median = res.meta.filename.replace('calints', 'median')
-                if os.path.exists(file_median):
-                    os.remove(file_median)
+                file_blot = res.meta.filename.replace('calints', 'blot')
+                file_outlier = res.meta.filename.replace('calints.fits', 'outlier_i2d.fits')
+                foutlier_local = os.path.basename(file_outlier)
+                for f in [file_median, file_blot, file_outlier, foutlier_local]:
+                    if os.path.exists(f):
+                        os.remove(f)
         
         # Setup output file.
         self.output_use_model = True

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -99,8 +99,13 @@ class Coron2Pipeline_spaceKLIP(Image2Pipeline):
             res = self.process_exposure_product(product, asn['asn_pool'], filebase)
             
             # Run outlier detection on CubeModel
-            if isinstance(res, datamodels.CubeModel):
-                res = self.outlier_detection.run(res)
+            try:
+                if isinstance(res, datamodels.CubeModel):
+                    res = self.outlier_detection.run(res)
+            except Exception as e:
+                log.warning('Error in outlier_detection step. Skipping outlier detection.')
+                log.error(e)
+                pass
             
             # Save results.
             suffix = 'calints' if isinstance(res, datamodels.CubeModel) else 'cal'

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -112,8 +112,8 @@ class Database():
                             cr_from_siaf=False,
                             assoc_using_targname=True):
         """
-        Read JWST stage 0 (\*uncal), 1 (\*rate or \*rateints), or 2 (\*cal or
-        \*calints) data into the Database.obs dictionary. It contains a table of
+        Read JWST stage 0 (uncal), 1 (rate or rateints), or 2 (cal or
+        calints) data into the Database.obs dictionary. It contains a table of
         metadata for each concatenation, which are identified automatically
         based on instrument, filter, pupil mask, and image mask. The tables can
         be edited by the user at any stage of the data reduction process and
@@ -653,7 +653,7 @@ class Database():
                           datapaths,
                           cr_from_siaf=False):
         """
-        Read JWST stage 3 data (this can be \*i2d data from the official JWST
+        Read JWST stage 3 data (this can be i2d data from the official JWST
         pipeline, or data products from the pyKLIP and classical PSF
         subtraction pipelines implemented in spaceKLIP) into the Database.red
         dictionary. It contains a table of metadata for each concatenation,

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -1471,7 +1471,7 @@ class Database():
 
 
 def create_database(output_dir,
-                    pid,
+                    pid=None,
                     obsids=None,
                     input_dir=None,
                     psflibpaths=None,
@@ -1539,7 +1539,9 @@ def create_database(output_dir,
         products. By default, only levels 0,1,2 data will be read and indexed.
     """
 
-    if input_dir is None:
+    if (pid is None) and (input_dir is None):
+        raise ValueError("Must provide either a pid or an input_dir")
+    elif input_dir is None:
         mast_dir = os.getenv('JWSTDOWNLOAD_OUTDIR')
         input_dir = os.path.join(mast_dir, f'{pid:05d}')
 
@@ -1548,7 +1550,7 @@ def create_database(output_dir,
         obsids = [obsids]
 
     # Cycle through all obsids and get the files in a single list
-    fitsfiles = [get_files(input_dir, pid, obsid=oid, **kwargs) for oid in obsids]
+    fitsfiles = [get_files(input_dir, pid=pid, obsid=oid, **kwargs) for oid in obsids]
     fitsfiles = [f for sublist in fitsfiles for f in sublist]
     datapaths = [os.path.join(input_dir, f) for f in fitsfiles]
 

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -419,8 +419,10 @@ class Database():
                         ww_sci = np.where(numdthpt == numdthpt_unique[0])[0]
                         ww_ref = np.where(numdthpt == numdthpt_unique[1])[0]
                     else:
+                        ww_sci = np.where(numdthpt == numdthpt_unique[0])[0]
+                        ww_ref = None
                         log.warning('  --> Could not identify science and reference files based on dither pattern')
-                        raise UserWarning('Please use psflibpaths to specify reference files')
+                        raise UserWarning('Consider using psflibpaths to specify reference files')
 
             # Make Astropy tables for concatenations.
             tab = Table(names=('TYPE',
@@ -511,7 +513,8 @@ class Database():
                                'float',
                                'object',
                                'object'))
-            for j in np.append(ww_sci, ww_ref):
+            ww_all = ww_sci if ww_ref is None else np.append(ww_sci, ww_ref)
+            for j in ww_all:
                 if j in ww_sci:
                     sci = True
                 else:
@@ -546,6 +549,9 @@ class Database():
                         pipeline = Detector1Pipeline()
                         input = datamodels.open(allpaths[ww][j])
                         maskfile = pipeline.get_reference_file(input, 'psfmask')
+                        if (maskfile is None) or (not os.path.exists(maskfile)):
+                            maskfile = 'NONE'
+                            
                         config_stpipe_log(suppress=True)  # Revert to default logging.
 
                     elif EXP_TYPE[ww][j] == 'MIR_4QPM' or EXP_TYPE[ww][j] == 'MIR_LYOT':

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -551,8 +551,8 @@ class Database():
                         maskfile = pipeline.get_reference_file(input, 'psfmask')
                         if (maskfile is None) or (not os.path.exists(maskfile)):
                             maskfile = 'NONE'
-                            
-                        config_stpipe_log(suppress=True)  # Revert to default logging.
+
+                        config_stpipe_log(suppress=False)  # Revert to default logging.
 
                     elif EXP_TYPE[ww][j] == 'MIR_4QPM' or EXP_TYPE[ww][j] == 'MIR_LYOT':
                         if APERNAME[ww][j] == 'MIRIM_MASK1065':

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -1248,7 +1248,7 @@ def create_bkg_mask(data, bpmask=None, nsigma=3, niter=3):
         bpmask = np.zeros_like(data, dtype=np.bool_)
     else:
         # Ensure bpmask isn't all True
-        if np.alltrue(bpmask):
+        if np.all(bpmask):
             bpmask = np.zeros_like(data, dtype=np.bool_)
 
     # Excpliitly mask out NaNs

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -91,7 +91,7 @@ class OneOverfStep(Step):
         model_type = option('median', 'mean', 'savgol', default='savgol') # Type of model to fit
         sat_frac = float(default=0.5) # Maximum saturation fraction for fitting
         combine_ints = boolean(default=True) # Combine integrations before ramp fitting
-        vertical_corr = boolean(default=True) # Apply horizontal correction
+        vertical_corr = boolean(default=True) # Apply vertical correction
         nproc = integer(default=4) # Number of processes to use
     """
 

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -252,7 +252,9 @@ class ImageTools():
 
                 # Write FITS file and PSF mask.
                 head_pri['NINTS'] = nints
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, 
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -351,7 +353,9 @@ class ImageTools():
                 head_sci['MASKCENY'] = maskceny
                 head_sci['CROP_SHIFTX'] = crop_shiftx  # Store crop shift.
                 head_sci['CROP_SHIFTY'] = crop_shifty
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -451,7 +455,9 @@ class ImageTools():
                 head_sci['STARCENY'] = starceny
                 head_sci['MASKCENX'] = maskcenx
                 head_sci['MASKCENY'] = maskceny
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -546,7 +552,9 @@ class ImageTools():
                 # Write FITS file and PSF mask.
                 head_pri['NINTS'] = nints
                 head_pri['EFFINTTM'] = effinttm
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -673,7 +681,9 @@ class ImageTools():
                     log.info('  --> Median subtraction: mean of frame median = %.2f' % np.mean(bg_median))
 
                 # Write FITS file and PSF mask.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -806,7 +816,9 @@ class ImageTools():
                         data_bg_sub[k] = data_improved_bgsub - np.nanmedian(data_improved_bgsub)
 
                     # Write FITS file and PSF mask.
-                    fitsfile = ut.write_obs(fitsfile, output_dir, data_bg_sub, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                    fitsfile = ut.write_obs(fitsfile, output_dir, data_bg_sub, erro, pxdq, head_pri, head_sci, is2d,
+                                            align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                            center_mask=center_mask, maskoffs=maskoffs)
 
                     # Update spaceKLIP database.
                     self.database.update_obs(key, j, fitsfile)
@@ -986,7 +998,9 @@ class ImageTools():
                 pxdq = np.concatenate(pxdq_split, axis=0)
 
                 # Write FITS file and PSF mask.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -1136,7 +1150,9 @@ class ImageTools():
                     new_dq = np.bitwise_or(pxdq.copy(), pxdq_temp).astype(np.uint32)
 
                 # Write FITS file and PSF mask.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -1306,7 +1322,9 @@ class ImageTools():
                                                     # (the bitwise steps otherwise return np.int64 which isn't FITS compatible)
 
                 # Write FITS file and PSF mask.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -1487,7 +1505,9 @@ class ImageTools():
                     plt.close(fig)
 
                 # Write FITS file and PSF mask.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -2177,7 +2197,9 @@ class ImageTools():
                     log.info('  --> Nan replacement: replaced %.0f nan pixel(s) with value ' % (np.sum(ww)) + str(cval) + ' -- %.2f%%' % (100. * np.sum(ww)/np.prod(ww.shape)))
 
                 # Write FITS file and PSF mask.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -2286,7 +2308,9 @@ class ImageTools():
                     pass
                 else:
                     head_pri['BLURFWHM'] = fact_temp * np.sqrt(8. * np.log(2.))  # Factor to convert from sigma to FWHM
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -2371,7 +2395,9 @@ class ImageTools():
                     pass
                 else:
                     head_pri['HPFSIZE'] = size_temp
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -2625,7 +2651,8 @@ class ImageTools():
 
                 # Write FITS file and PSF mask.
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
-                                        align_shift, center_shift, align_mask, center_mask, maskoffs)
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -2769,7 +2796,9 @@ class ImageTools():
                     head_pri['XOFFSET'] = xoffset_new
                     head_pri['YOFFSET'] = yoffset_new
                     output_dir = os.path.dirname(self.database.obs[key]['FITSFILE'][j])
-                    fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                    fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                            align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                            center_mask=center_mask, maskoffs=maskoffs)
 
                     # Update spaceKLIP database.
                     self.database.update_obs(key, j, fitsfile, maskfile, xoffset=xoffset_new, yoffset=yoffset_new)
@@ -2829,7 +2858,7 @@ class ImageTools():
         """
 
         # DEPRECATION WARNING
-        log.warning('This function is deprecated. Use `calculate_centers` and `shift_frames` instead.')
+        raise DeprecationWarning('This function is deprecated. Use `calculate_centers` and `shift_frames` instead.')
 
         # Update NIRCam coronagraphy centers, i.e., change SIAF CRPIX position
         # to true mask center determined by Jarron
@@ -3340,7 +3369,9 @@ class ImageTools():
                 head_sci['CRPIX1'] = self.database.obs[key]['CRPIX1'][j]
                 head_sci['CRPIX2'] = self.database.obs[key]['CRPIX2'][j]
 
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -3425,7 +3456,9 @@ class ImageTools():
 
             for j in ww_all:
                 target_file = self.database.obs[key]['FITSFILE'][j]
-                data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs = ut.read_obs(target_file)
+                # data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs = ut.read_obs(target_file)
+                (data, erro, pxdq, head_pri, head_sci, is2d,
+                 align_shift, center_shift, align_mask, center_mask, maskoffs) = ut.read_obs(fitsfile)
                 maskfile = self.database.obs[key]['MASKFILE'][j]
                 mask = ut.read_msk(maskfile)
 
@@ -3466,8 +3499,11 @@ class ImageTools():
                         mask = result.data
 
                     # Write FITS file and PSF mask.
-                    fitsfile = ut.write_obs(target_file, output_dir, data_list, err_list, dq_list, head_pri, head_sci, is2d, imshifts,
-                                            maskoffs)
+                    # fitsfile = ut.write_obs(target_file, output_dir, data_list, err_list, dq_list, head_pri, head_sci, is2d, imshifts,
+                    #                         maskoffs)
+                    fitsfile = ut.write_obs(target_file, output_dir, data_list, err_list, dq_list, head_pri, head_sci, is2d,
+                                            align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                            center_mask=center_mask, maskoffs=maskoffs)
                     maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                     # Update spaceKLIP database.
@@ -3719,7 +3755,7 @@ class ImageTools():
 
         """
         #### DEPRECATION WARNING ####
-        log.warning('This function is deprecated. Use `calculate_alignment` and `shift_frames` instead.')
+        raise DeprecationWarning('This function is deprecated. Use `calculate_alignment` and `shift_frames` instead.')
 
         # Set output directory.
         output_dir = os.path.join(self.database.output_dir, subdir)
@@ -4321,7 +4357,9 @@ class ImageTools():
                     head_sci['STARCENX'] = starcenx
                     head_sci['STARCENY'] = starceny
 
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.
@@ -4653,7 +4691,9 @@ class ImageTools():
                 head_sci['CRPIX2'] = crpix2
 
                 # Save fits file.
-                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)
+                fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d,
+                                        align_shift=align_shift, center_shift=center_shift, align_mask=align_mask,
+                                        center_mask=center_mask, maskoffs=maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
 
                 # Update spaceKLIP database.

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1312,7 +1312,8 @@ class ImageTools():
                          interp2d_kwargs={},
                          types=['SCI', 'SCI_TA', 'SCI_BG', 'REF', 'REF_TA', 'REF_BG'],
                          subdir='bpcleaned',
-                         restrict_to=None):
+                         restrict_to=None,
+                         plot=True):
         """
         Clean bad pixels.
 
@@ -1402,12 +1403,13 @@ class ImageTools():
                 maskfile = self.database.obs[key]['MASKFILE'][j]
                 mask = ut.read_msk(maskfile)
 
-                fig = plt.figure()
-                ax = plt.gca()
-                ax.hist(data.flatten(),
-                        bins=int(np.sqrt(len(data.flatten()))),
-                        histtype='step',
-                        label='Pre Cleaning')
+                if plot:
+                    fig = plt.figure()
+                    ax = plt.gca()
+                    ax.hist(data.flatten(),
+                            bins=int(np.sqrt(len(data.flatten()))),
+                            histtype='step',
+                            label='Pre Cleaning')
 
                 # Make copy of DQ array
                 pxdq_temp = pxdq.copy()
@@ -1456,20 +1458,21 @@ class ImageTools():
                                                     # (the bitwise steps otherwise return np.int64 which isn't FITS compatible)
 
                 # Finish figure for this file
-                ax.hist(data.flatten(),
-                        bins=int(np.sqrt(len(data.flatten()))),
-                        histtype='step',
-                        label='Post Cleaning')
-                ax.legend()
-                # ax.set_xscale('log')
-                ax.set_yscale('log')
-                ax.tick_params(which='both', direction='in', top=True, right=True, labelsize=12)
-                ax.set_xlabel("Pixel Value", fontsize=14)
-                ax.set_ylabel("Frequency", fontsize=12)
-                ax.set_title(f"{os.path.basename(fitsfile)} \n Original vs. Cleaned Data", fontsize=16)
-                output_file = os.path.join(output_dir, tail.replace('.fits', '_hist.png'))
-                plt.savefig(output_file)
-                plt.close(fig)
+                if plot:
+                    ax.hist(data.flatten(),
+                            bins=int(np.sqrt(len(data.flatten()))),
+                            histtype='step',
+                            label='Post Cleaning')
+                    ax.legend()
+                    # ax.set_xscale('log')
+                    ax.set_yscale('log')
+                    ax.tick_params(which='both', direction='in', top=True, right=True, labelsize=12)
+                    ax.set_xlabel("Pixel Value", fontsize=14)
+                    ax.set_ylabel("Frequency", fontsize=12)
+                    ax.set_title(f"{os.path.basename(fitsfile)} \n Original vs. Cleaned Data", fontsize=16)
+                    output_file = os.path.join(output_dir, tail.replace('.fits', '_hist.png'))
+                    plt.savefig(output_file)
+                    plt.close(fig)
 
                 # Write FITS file and PSF mask.
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, new_dq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs)

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -2271,7 +2271,7 @@ class ImageTools():
                     except:
                         fact_temp = fact
                     if self.database.obs[key]['TELESCOP'][j] == 'JWST':
-                        if self.database.obs[key]['EXP_TYPE'][j] in ['NRC_CORON']:
+                        if self.database.obs[key]['EXP_TYPE'][j] in ['NRC_CORON', 'NRC_TACONFIRM', 'NRC_TACQ']:
                             diam = 5.2
                         else:
                             diam = JWST_CIRCUMSCRIBED_DIAMETER

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -62,6 +62,7 @@ from pyklip.instruments.JWST import JWSTData
 
 # jwst imports
 import jwst.datamodels
+from jwst.datamodels import dqflags
 from stdatamodels.jwst import datamodels
 from jwst.datamodels import ModelContainer, ModelLibrary
 from jwst.resample import resample_step
@@ -614,6 +615,7 @@ class ImageTools():
                 data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs = ut.read_obs(fitsfile)
                 maskfile = self.database.obs[key]['MASKFILE'][j]
                 mask = ut.read_msk(maskfile)
+                pxmask_donotuse = ut.get_dqmask(pxdq, 'DO_NOT_USE', return_bool=True)
 
                 # Skip file types that are not in the list of types.
                 if self.database.obs[key]['TYPE'][j] in types:
@@ -624,7 +626,7 @@ class ImageTools():
                     data_temp = data.copy()
                     # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     # data_temp[pxdq != 0] = np.nan
-                    data_temp[pxdq & 1 == 1] = np.nan
+                    data_temp[pxmask_donotuse] = np.nan
                     # else:
                     #     data_temp[pxdq & 1 == 1] = np.nan
                     if method == 'robust':
@@ -888,7 +890,8 @@ class ImageTools():
                     sci_bg_data_split[k] = np.nanmedian(sci_bg_data_split[k], axis=0)
                     nsample = np.sum(np.logical_not(np.isnan(sci_bg_erro_split[k])), axis=0)
                     sci_bg_erro_split[k] = np.true_divide(np.sqrt(np.nansum(sci_bg_erro_split[k]**2, axis=0)), nsample)
-                    sci_bg_pxdq_split[k] = np.sum(sci_bg_pxdq_split[k] & 1 == 1, axis=0) != 0
+                    sci_split_donotuse = ut.get_dqmask(sci_bg_pxdq_split[k], 'DO_NOT_USE', return_bool=True)
+                    sci_bg_pxdq_split[k] = np.sum(sci_split_donotuse, axis=0) != 0
             else:
                 sci_bg_data = None
 
@@ -925,7 +928,8 @@ class ImageTools():
                     ref_bg_data_split[k] = np.nanmedian(ref_bg_data_split[k], axis=0)
                     nsample = np.sum(np.logical_not(np.isnan(ref_bg_erro_split[k])), axis=0)
                     ref_bg_erro_split[k] = np.true_divide(np.sqrt(np.nansum(ref_bg_erro_split[k]**2, axis=0)), nsample)
-                    ref_bg_pxdq_split[k] = np.sum(ref_bg_pxdq_split[k] & 1 == 1, axis=0) != 0
+                    ref_split_donotuse = ut.get_dqmask(ref_bg_pxdq_split[k], 'DO_NOT_USE', return_bool=True)
+                    ref_bg_pxdq_split[k] = np.sum(ref_split_donotuse, axis=0) != 0
             else:
                 ref_bg_data = None
 
@@ -964,18 +968,19 @@ class ImageTools():
                 pxdq_split = np.array_split(pxdq, split_inds, axis=0)
                 # For each dataset, need to decide what to use as the background and subtract
                 for k in range(len(split_inds)+1):
+                    pxmask_split_donotuse = ut.get_dqmask(pxdq_split[k], 'DO_NOT_USE', return_bool=True)
                     if (sci and sci_bg_data is not None) or (not sci and ref_bg_data is None):
                         if not sci and ref_bg_data is None:
                             log.warning('  --> Could not find reference background, attempting to use science background')
                         data_split[k] = data_split[k] - sci_bg_data_split[k]
                         erro_split[k] = np.sqrt(erro_split[k]**2 + sci_bg_erro_split[k]**2)
-                        pxdq_split[k][np.logical_not(pxdq_split[k] & 1 == 1) & (sci_bg_pxdq_split[k] != 0)] += 1
+                        pxdq_split[k][(~pxmask_split_donotuse) & (sci_bg_pxdq_split[k] != 0)] += 1
                     elif (not sci and ref_bg_data is not None) or (sci and sci_bg_data is None):
                         if sci and sci_bg_data is None:
                             log.warning('  --> Could not find science background, attempting to use reference background')
                         data_split[k] = data_split[k] - ref_bg_data_split[k]
                         erro_split[k] = np.sqrt(erro_split[k]**2 + ref_bg_erro_split[k]**2)
-                        pxdq_split[k][np.logical_not(pxdq_split[k] & 1 == 1) & (ref_bg_pxdq_split[k] != 0)] += 1
+                        pxdq_split[k][(~pxmask_split_donotuse) & (ref_bg_pxdq_split[k] != 0)] += 1
                 data = np.concatenate(data_split, axis=0)
                 erro = np.concatenate(erro_split, axis=0)
                 pxdq = np.concatenate(pxdq_split, axis=0)
@@ -1080,6 +1085,7 @@ class ImageTools():
                 data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs = ut.read_obs(fitsfile)
                 maskfile = self.database.obs[key]['MASKFILE'][j]
                 mask = ut.read_msk(maskfile)
+                pxmask_nonsci = ut.get_dqmask(pxdq, 'NON_SCIENCE', return_bool=True)
 
                 if set_dq_zero:  # set_dq_zero
                     # Make copy of DQ array filled with zeros, i.e. all good pixels
@@ -1102,12 +1108,13 @@ class ImageTools():
                         head, tail = os.path.split(fitsfile)
                         if method_split[k] == 'dqarr':
                             log.info('  --> Method ' + method_split[k] + ': ' + tail)
-                            # Flag any pixels marked as DO_NOT_USE that aren't NONSCIENCE
-                            pxdq_temp = (np.isnan(data) | (pxdq_temp & 1 == 1)) \
-                                & np.logical_not(pxdq_temp & 512 == 512)
+                            # Flag any pixels marked as DO_NOT_USE that aren't NON_SCIENCE
+                            temp_donotuse = ut.get_dqmask(pxdq_temp, 'DO_NOT_USE', return_bool=True)
+                            temp_nonsci = ut.get_dqmask(pxdq_temp, 'NON_SCIENCE', return_bool=True)
+                            pxdq_temp = (np.isnan(data) | temp_donotuse) & (~temp_nonsci)
                         elif method_split[k] == 'sigclip':
                             log.info('  --> Method ' + method_split[k] + ': ' + tail)
-                            self.find_bad_pixels_sigclip(data, erro, pxdq_temp, pxdq & 512 == 512, sigclip_kwargs)
+                            self.find_bad_pixels_sigclip(data, erro, pxdq_temp, pxmask_nonsci, sigclip_kwargs)
                         elif method_split[k] == 'custom':
                             log.info('  --> Method ' + method_split[k] + ': ' + tail)
                             if self.database.obs[key]['TYPE'][j] not in ['SCI_TA', 'REF_TA']:
@@ -1247,6 +1254,7 @@ class ImageTools():
                 data, erro, pxdq, head_pri, head_sci, is2d, align_shift, center_shift, align_mask, center_mask, maskoffs = ut.read_obs(fitsfile)
                 maskfile = self.database.obs[key]['MASKFILE'][j]
                 mask = ut.read_msk(maskfile)
+                pxmask_nonsci = ut.get_dqmask(pxdq, 'NON_SCIENCE', return_bool=True)
 
                 # Skip file types that are not in the list of types.
                 if self.database.obs[key]['TYPE'][j] in types:
@@ -1256,13 +1264,15 @@ class ImageTools():
                     # if self.database.obs[key]['TELESCOP'][j] == 'JWST' and self.database.obs[key]['INSTRUME'][j] == 'NIRCAM':
                     #     pxdq_temp = (pxdq_temp != 0) & np.logical_not(pxdq_temp & 512 == 512)
                     # else:
-                    pxdq_temp = (np.isnan(data) | (pxdq_temp & 1 == 1)) & np.logical_not(pxdq_temp & 512 == 512)
+                    temp_donotuse = ut.get_dqmask(pxdq_temp, 'DO_NOT_USE', return_bool=True)
+                    temp_nonsci = ut.get_dqmask(pxdq_temp, 'NON_SCIENCE', return_bool=True)
+                    pxdq_temp = (np.isnan(data) | temp_donotuse) & (~temp_nonsci)
                     method_split = method.split('+')
                     for k in range(len(method_split)):
                         head, tail = os.path.split(fitsfile)
                         if method_split[k] == 'sigclip':
                             log.info('  --> Method ' + method_split[k] + ': ' + tail)
-                            self.find_bad_pixels_sigclip(data, erro, pxdq_temp, pxdq & 512 == 512, sigclip_kwargs)
+                            self.find_bad_pixels_sigclip(data, erro, pxdq_temp, pxmask_nonsci, sigclip_kwargs)
                         elif method_split[k] == 'custom':
                             log.info('  --> Method ' + method_split[k] + ': ' + tail)
                             if self.database.obs[key]['TYPE'][j] not in ['SCI_TA', 'REF_TA']:
@@ -1289,7 +1299,7 @@ class ImageTools():
                 #  The pxdq variable here is effectively just the DO_NOT_USE flag, discarding other bits.
                 #  We want to make a new dq which retains the other bits as much as possible.
                 #  first, retain all the other bits (bits greater than 1), then add in the new/cleaned DO_NOT_USE bit
-                do_not_use = jwst.datamodels.dqflags.pixel['DO_NOT_USE']
+                do_not_use = dqflags.pixel['DO_NOT_USE']
                 new_dq = np.bitwise_and(pxdq.copy(), np.invert(do_not_use))  # retain all other bits except the do_not_use bit
                 new_dq = np.bitwise_or(new_dq, pxdq_temp)  # add in the do_not_use bit from the cleaned version
                 new_dq = new_dq.astype(np.uint32)   # ensure correct output type for saving
@@ -1415,7 +1425,9 @@ class ImageTools():
                 pxdq_temp = pxdq.copy()
 
                 # Don't want to clean anything that isn't bad or is a non-science pixel
-                pxdq_temp = (np.isnan(data) | (pxdq_temp & 1 == 1)) & np.logical_not(pxdq_temp & 512 == 512)
+                temp_donotuse = ut.get_dqmask(pxdq_temp, 'DO_NOT_USE', return_bool=True)
+                temp_nonsci = ut.get_dqmask(pxdq_temp, 'NON_SCIENCE', return_bool=True)
+                pxdq_temp = (np.isnan(data) | temp_donotuse) & (~temp_nonsci)
 
                 # Skip file types that are not in the list of types.
                 if self.database.obs[key]['TYPE'][j] in types:
@@ -1451,7 +1463,7 @@ class ImageTools():
                 #  We want to make a new dq which retains the other bits as much as possible.
                 #  first, retain all the other bits (bits greater than 1), then add in the new/cleaned DO_NOT_USE bit
 
-                do_not_use = jwst.datamodels.dqflags.pixel['DO_NOT_USE']
+                do_not_use = dqflags.pixel['DO_NOT_USE']
                 new_dq = np.bitwise_and(pxdq.copy(), np.invert(do_not_use))  # retain all other bits except the do_not_use bit
                 new_dq = np.bitwise_or(new_dq, pxdq_temp)  # add in the do_not_use bit from the cleaned version
                 new_dq = new_dq.astype(np.uint32)   # ensure correct output type for saving
@@ -2041,7 +2053,8 @@ class ImageTools():
             interp2d_kwargs['size'] = 5
 
         # Fix bad pixels using interpolation of neighbors.
-        ww = (pxdq != 0) & np.logical_not(pxdq & 512 == 512)
+        pxmask_nonsci = ut.get_dqmask(pxdq, 'NON_SCIENCE', return_bool=True)
+        ww = (pxdq != 0) & (~pxmask_nonsci)
         log.info('  --> Method interp2d: fixing %.0f bad pixel(s) -- %.2f%%' % (np.sum(ww), 100. * np.sum(ww) / np.prod(ww.shape)))
 
         # NaN pixels to be replaced with interpolation

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -3402,6 +3402,7 @@ class ImageTools():
             os.makedirs(output_dir)
 
         # Loop through concatenations.
+        sci_good = False
         for i, key in enumerate(self.database.obs.keys()):
             # Read FITS file and PSF mask.
 
@@ -3410,7 +3411,10 @@ class ImageTools():
             # Find science and reference files.
             ww_sci = np.where(self.database.obs[key]['TYPE'] == 'SCI')[0]
             if len(ww_sci) == 0:
-                raise UserWarning('Could not find any science files')
+                # raise UserWarning('Could not find any science files')
+                print(f'Warning: Could not find any science files. Skipping {key}.')
+                continue
+            sci_good = True
             ww_ref = np.where(self.database.obs[key]['TYPE'] == 'REF')[0]
             ww_all = np.append(ww_sci, ww_ref)
 
@@ -3469,7 +3473,8 @@ class ImageTools():
                     # Update spaceKLIP database.
                     self.database.update_obs(key, j, fitsfile, maskfile)
                     pass
-
+        if not sci_good:
+            raise(ValueError('No science frames found in database concatenations'))
 
     def find_nircam_centers(self,
                             data0,
@@ -3761,13 +3766,17 @@ class ImageTools():
 
         # Loop through concatenations.
         database_temp = deepcopy(self.database.obs)
+        sci_good = False
         for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
 
             # Find science and reference files.
             ww_sci = np.where(self.database.obs[key]['TYPE'] == 'SCI')[0]
             if len(ww_sci) == 0:
-                raise UserWarning('Could not find any science files')
+                # raise UserWarning('Could not find any science files')
+                print(f'Warning: Could not find any science files. Skipping {key}.')
+                continue
+            sci_good = True
             ww_ref = np.where(self.database.obs[key]['TYPE'] == 'REF')[0]
             ww_all = np.append(ww_sci, ww_ref)
 
@@ -4037,6 +4046,9 @@ class ImageTools():
                 plt.show()
                 plt.close(fig)
 
+        if not sci_good:
+            raise(ValueError('No science frames found in database concatenations'))
+
 
     def calculate_alignment(self,
                             method='fourier',
@@ -4133,13 +4145,17 @@ class ImageTools():
 
         # Loop through concatenations.
         database_temp = deepcopy(self.database.obs)
+        sci_good = False
         for i, key in enumerate(self.database.obs.keys()):
             log.info('--> Concatenation ' + key)
 
             # Find science and reference files.
             ww_sci = np.where(self.database.obs[key]['TYPE'] == 'SCI')[0]
             if len(ww_sci) == 0:
-                raise UserWarning('Could not find any science files')
+                # raise UserWarning('Could not find any science files')
+                print(f'Warning: Could not find any science files. Skipping {key}.')
+                continue
+            sci_good = True
             ww_ref = np.where(self.database.obs[key]['TYPE'] == 'REF')[0]
             ww_all = np.append(ww_sci, ww_ref)
 
@@ -4409,6 +4425,9 @@ class ImageTools():
                     log.info(f" Plot saved in {output_file}")
                 plt.show()
                 plt.close(fig)
+
+        if not sci_good:
+            raise(ValueError('No science frames found in database concatenations'))
 
     def shift_frames(self,
                      method='fourier',

--- a/spaceKLIP/logging_tools.py
+++ b/spaceKLIP/logging_tools.py
@@ -6,6 +6,36 @@ _log.setLevel(logging.INFO)
 from contextlib import contextmanager
 
 @contextmanager
+def crds_logging_disabled(highest_level=-3):
+    """
+    A context manager that will prevent any logging messages
+    triggered during the body from being processed.
+
+    Usage to suppress levels up to Critical:
+
+        >>> with crds_logging_disabled(-3):
+        >>>     do_something()
+
+    Parameters
+    ----------
+    highest_level : int
+        For CRDS, logging levels are defined as:
+        -3: CRITICAL
+        -2: ERROR
+        -1: WARNING
+         0: INFO
+         1: DEBUG
+    """
+    from crds.core import log as crds_log
+    previous_level = crds_log.get_verbose()
+    crds_log.set_verbose(highest_level)
+    try:
+        yield
+    finally:
+        crds_log.set_verbose(previous_level)
+
+
+@contextmanager
 def all_logging_disabled(highest_level=logging.CRITICAL):
     """
     A context manager that will prevent any logging messages

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -583,15 +583,18 @@ def display_image_comparisons(database,
 
         # Check if any SCI data remains after filtering.
         if not any(row['TYPE'] == 'SCI' for row in filtered_table):
-            print(f"No SCI type files found in key: {key}."
-            f" Exiting. Check 'restrict_to' criteria.")
-            return
+            print(f"No SCI type files found in key: {key}.")
+            continue
        
         # Identify the first SCI frame for subtraction, store it for later use.
         first_sci_file = next((row['FITSFILE'] for row in filtered_table if row['TYPE'] == 'SCI'), None)
         root_dir = first_sci_file.split(os.sep)[0]
         for base_dir in base_dirs:
             image_files[base_dir]['first_sci_file'] = os.path.join(root_dir, base_dir, os.path.basename(first_sci_file))
+
+    if len(filtered_files)==0:
+        print("No files found. Check 'restrict_to' criteria. Exiting.")
+        return 
 
     # Create figure of appropriate size.
     num_dirs = len(base_dirs)

--- a/spaceKLIP/psflib.py
+++ b/spaceKLIP/psflib.py
@@ -26,7 +26,6 @@ import os
 import warnings
 import glob
 import re
-import mocapy
 import pandas as pd
 from astropy.io import fits
 from spaceKLIP import mast
@@ -236,6 +235,8 @@ def build_refdb(idir,odir='.',suffix='calints',overwrite=False,
     #       - slightly wrong SIMBAD names
     # - logic for if 'HAS_DISK','HAS_CANDS' have a mix of 'unknown' and bool values
     
+    import mocapy
+
     # Check that you won't accidentally overwrite an existing csv.
     outpath = os.path.join(odir,'ref_lib.csv')
     if os.path.exists(outpath):

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -16,7 +16,6 @@ import numpy as np
 import pysiaf
 import astropy.io.fits as pyfits
 from astroquery.svo_fps import SvoFps
-from astropy.nddata.bitmask import _is_bit_flag
 
 # scipy imports
 import scipy.ndimage.interpolation as sinterp
@@ -1202,21 +1201,34 @@ def gaussian_kernel(sigma_x=1, sigma_y=1, theta_degrees=0, n=6):
 
 
 def get_dqmask(dqarr, bitvalues):
-    """
-    Get DQ mask from DQ array.
+    """ Get DQ mask from DQ array.
 
-    Given some DQ array and a list of bit values, return a mask
-    for the pixels that have any of the specified bit values.
+    Given some DQ array and a list of bit values, return a filtered
+    bit mask for the pixels that have the specified bit values.
+
+    To get a bad pixel mask of certain types, for instance:
+        bp_mask = get_dqmask(dq, ['SATURATED', 'JUMP_DET', 'RC']) > 0
 
     Parameters
     ----------
     dqarr : ndarray
         DQ array. Either 2D or 3D.
     bitvalues : list
-        List of bit values to use for DQ mask.
-        These values must be powers of 2 (e.g., 1, 2, 4, 8, 16, ...),
+        List of bit values or mnemonics to use for DQ mask. 
+        Numbered values must be powers of 2 (e.g., 1, 2, 4, 8, 16, ...),
         representing the specific DQ bit flags.
     """
+
+    from astropy.nddata.bitmask import _is_bit_flag
+    from jwst.datamodels import dqflags
+
+    # Ensure bitvalues is a list or ndarray
+    if not isinstance(bitvalues, (list, np.ndarray)):
+        bitvalues = [bitvalues]
+
+    # Convert any string mnemonics to bit values
+    bitvalues = [dqflags.pixel[val] if isinstance(val, str) else val 
+                 for val in bitvalues]
 
     for v in bitvalues:
         if not _is_bit_flag(v):

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -1200,7 +1200,7 @@ def gaussian_kernel(sigma_x=1, sigma_y=1, theta_degrees=0, n=6):
     return kernel
 
 
-def get_dqmask(dqarr, bitvalues):
+def get_dqmask(dqarr, bitvalues, return_bool=False):
     """ Get DQ mask from DQ array.
 
     Given some DQ array and a list of bit values, return a filtered
@@ -1217,6 +1217,15 @@ def get_dqmask(dqarr, bitvalues):
         List of bit values or mnemonics to use for DQ mask. 
         Numbered values must be powers of 2 (e.g., 1, 2, 4, 8, 16, ...),
         representing the specific DQ bit flags.
+    return_bool : bool
+        If True, return a boolean mask instead of an integer DQ mask.
+        Returns a boolean pixel mask showing which pixels have any of 
+        the specified bit values set.
+
+    Returns
+    -------
+    ndarray
+        DQ mask with only requested bit values set to True.
     """
 
     from astropy.nddata.bitmask import _is_bit_flag
@@ -1240,7 +1249,10 @@ def get_dqmask(dqarr, bitvalues):
     for bitval in bitvalues:
         dqmask = dqmask | (dqarr & bitval)
 
-    return dqmask
+    if return_bool:
+        return dqmask > 0
+    else:
+        return dqmask
 
 
 def pop_pxar_kw(filepaths):


### PR DESCRIPTION
I have updated SpaceKLIP with a few necessary changes to work with Python 3.12. There are also a number of small bug fixes that are necessary for roll-subtracted direct imaging datasets (database tracking and pipeline processing). I have validated these changes up to ImageTool alignment. No changes to code affecting higher level analysis have been performed yet.