### PR TITLE
alignment fix for new jwst/numpy/scipy versions

### DIFF
--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -626,7 +626,7 @@ def alignlsq(shift,
         Residual image collapsed into one dimension.
     """
     
-    # Ensure data type if float64.
+    # Ensure data type is float64.
     image = np.asarray(image, dtype=np.float64)
     ref_image = np.asarray(ref_image, dtype=np.float64)
     if mask is not None:

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -625,6 +625,12 @@ def alignlsq(shift,
     imres : 1D-array
         Residual image collapsed into one dimension.
     """
+    
+    # Ensure data type if float64.
+    image = np.asarray(image, dtype=np.float64)
+    ref_image = np.asarray(ref_image, dtype=np.float64)
+    if mask is not None:
+        mask = np.asarray(mask, dtype=np.float64)
 
     if mask is None:
         return (ref_image - shift[2] * imshift(image, shift[:2], method=method, pad=False, kwargs=kwargs)).ravel()


### PR DESCRIPTION
After a fresh installation of spaceKLIP, which pulled newer versions of JWST, NumPy, and SciPy, the `calculate_alignment` step began producing results that differed from those in an older spaceKLIP installation. I traced where the outputs first diverged within `calculate_alignment` and identified the source as the `alignlsq` function in `utils.py`, which is called internally by that step. The issue was that the arrays passed into `alignlsq` were float32, and led to incorrect behavior downstream in the new environment. I updated `alignlsq` to explicitly cast the inputs to float64. With this change in place, the alignment results match the older environment as expected.

I’ve included slides that illustrate the observed differences (all the way through to `extract_companions`) between the two environments and show the results of the float64 fix.

Additional note: the “new environment” labeled in the slides also includes a recent pyKLIP patch (related to NumPy-version behavior) that previously caused the ADI step to crash and is now resolved by: https://bitbucket.org/pyKLIP/pyklip/pull-requests/67 


[align_bug.pptx](https://github.com/user-attachments/files/25242219/align_bug.pptx)
