### PR TITLE
quick "fix" when dealing with a custom bad pixel map

### DIFF
--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -2588,7 +2588,7 @@ class ImageTools():
         # pxdq[pxdq_custom] = 1
         # log.info('  --> Method custom: flagged %.0f additional bad pixel(s) -- %.2f%%' % (np.sum(pxdq) - np.sum(pxdq_orig), 100. * (np.sum(pxdq) - np.sum(pxdq_orig)) / np.prod(pxdq.shape)))
         if key in custom_kwargs.keys():
-            if np.array(custom_kwargs[key]).shape == pxdq_orig.shape:
+            if np.array(custom_kwargs[key]).shape == pxdq_orig.shape[1:]:
                 pxdq_custom = custom_kwargs[key] != 0
             else:
                 pxqd_temp = np.zeros(pxdq.shape)


### PR DESCRIPTION
While testing the find_bad_pixels_custom function, with the custom_mask built as described in the tutorial notebooks, I realised that none of the flagged bad pixels were saved in the dq array. This meant that the bad pixel flagged manually never got fixed in the following clean_bad_pixels step.

To counter this issue, I tweaked the first condition in the find_bad_pixels_custom function to compare the shape of the inputted custom_mask to the pxdq_orig[1:] (removing the shape information linked to the number of integrations).

This might need some further testing, but the code might ressemble past versions of this function.