### PR TITLE
JWST Stage 1/2 Verbose Logging Fix

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -652,6 +652,10 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     # Print all info message if verbose, otherwise only errors or critical.
     from .logging_tools import all_logging_disabled
     log_level = logging.INFO if verbose else logging.ERROR
+    logging.basicConfig(level=log_level,
+                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                        force=True)
+    log.setLevel(log_level)
 
     # Create output directory if it doesn't exist.
     if not os.path.exists(output_dir):

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -188,6 +188,10 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     # Print all info message if verbose, otherwise only errors or critical.
     from .logging_tools import all_logging_disabled
     log_level = logging.INFO if verbose else logging.ERROR
+    logging.basicConfig(level=log_level,
+                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                        force=True)
+    log.setLevel(log_level)
 
     # Create output directory if it doesn't exist.
     if not os.path.exists(output_dir):


### PR DESCRIPTION
At some point the JWST pipeline changed how logging was output when using either .run() or .call(). The spaceKLIP pipeline uses the .run() method in `coron1pipeline.py` and `coron2pipeline.py`, which does not configure loggers by default (https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/logging.html).  I added in a few lines to both .py files so that more meaningful logs are output when `verbose` is True. 

Once merged this should close the bug ticket : https://github.com/spacetelescope/spaceKLIP/issues/286 