### PR TITLE
Stage1/2 Verbose logging - removed two lines

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -655,7 +655,6 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     logging.basicConfig(level=log_level,
                         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
                         force=True)
-    log.setLevel(log_level)
 
     # Create output directory if it doesn't exist.
     if not os.path.exists(output_dir):

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -191,7 +191,6 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     logging.basicConfig(level=log_level,
                         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
                         force=True)
-    log.setLevel(log_level)
 
     # Create output directory if it doesn't exist.
     if not os.path.exists(output_dir):


### PR DESCRIPTION
Removing two lines that are wrongly resetting the log_level. PR from earlier https://github.com/spacetelescope/spaceKLIP/pull/299 still fixes the issue when verbose=True but these lines which I am removing here kept resetting the log_level when verbose=False. 