### PR TITLE
Fix NaNs in the ERR Array

### DIFF
--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -3358,8 +3358,15 @@ class ImageTools():
                     # Replace nans.
                     head, tail = os.path.split(fitsfile)
                     log.info('  --> Nan replacement: ' + tail)
+                    
+                    # Replace NaNs in SCI data.
                     ww = np.isnan(data)
                     data[ww] = cval
+
+                    # Replace NaNs in ERR data.
+                    ww_erro = np.isnan(erro)
+                    erro[ww_erro] = cval
+
                     log.info('  --> Nan replacement: replaced %.0f nan pixel(s) with value ' % (np.sum(ww)) + str(cval) + ' -- %.2f%%' % (100. * np.sum(ww)/np.prod(ww.shape)))
 
                 # Write FITS file and PSF mask.

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -3365,7 +3365,7 @@ class ImageTools():
 
                     # Replace NaNs in ERR data.
                     ww_erro = np.isnan(erro)
-                    erro[ww_erro] = cval
+                    erro[ww_erro] = 1e6
 
                     log.info('  --> Nan replacement: replaced %.0f nan pixel(s) with value ' % (np.sum(ww)) + str(cval) + ' -- %.2f%%' % (100. * np.sum(ww)/np.prod(ww.shape)))
 


### PR DESCRIPTION
A bug was reported in the `replace_nans` function in `imagetools.py`: NaN values in the ERR array were not being replaced. As a result, the shifting function executed after this step return an ERR array containing only NaNs. The issue was reported in [spaceKLIP issue #296](https://github.com/spacetelescope/spaceKLIP/issues/296).

The clean bad pixel steps only handle NaNs in the SCI array, so NaNs in the ERR array remained after those stages.

NaN values in the ERR array are now replaced with an obviously large value to indicate that the uncertainty is unknown.

Attaching a before and after the bug fix image of the ERR array. 
<img width="702" height="553" alt="Error Map after shifted" src="https://github.com/user-attachments/assets/b660eb56-76d9-4276-a35f-c6614ddb1902" />
<img width="704" height="553" alt="image" src="https://github.com/user-attachments/assets/892397dc-035e-4422-bad6-fcd8432f2dce" />


Closes #296 
