### PR TITLE
Update FITS header comments

### DIFF
--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -182,6 +182,14 @@ def run_obs(database,
                     head_sci = fits.getheader(database.obs[key]['FITSFILE'][ww_sci[0]], 'SCI')
                     head_sci['NAXIS'] = 2
                     hdul = fits.open(datapath)
+                    
+                    # Adding comments to a handful of the FITS header keywords populated by pyKLIP.
+                    hdul[0].header.comments['PSFCENTX'] = '[pixel] PSF center along the x axis'
+                    hdul[0].header.comments['PSFCENTY'] = '[pixel] PSF center along the x axis'
+                    hdul[0].header.comments['STARCENX'] = 'Star center along the X axis, 1-indexed'
+                    hdul[0].header.comments['STARCENY'] = 'Star center along the Y axis, 1-indexed'
+
+                    
                     hdul[0].header['TELESCOP'] = (database.obs[key]['TELESCOP'][ww_sci[0]], head_primary.comments["TELESCOP"])
                     hdul[0].header['TARGPROP'] = (database.obs[key]['TARGPROP'][ww_sci[0]], head_primary.comments["TARGPROP"])
                     hdul[0].header['TARG_RA'] = (database.obs[key]['TARG_RA'][ww_sci[0]], head_primary.comments["TARG_RA"])
@@ -189,8 +197,8 @@ def run_obs(database,
                     hdul[0].header['INSTRUME'] = (database.obs[key]['INSTRUME'][ww_sci[0]], head_primary.comments["INSTRUME"])
                     hdul[0].header['DETECTOR'] = (database.obs[key]['DETECTOR'][ww_sci[0]], head_primary.comments["DETECTOR"])
                     hdul[0].header['FILTER'] = (database.obs[key]['FILTER'][ww_sci[0]], head_primary.comments["FILTER"])
-                    hdul[0].header['CWAVEL'] = database.obs[key]['CWAVEL'][ww_sci[0]]
-                    hdul[0].header['DWAVEL'] = database.obs[key]['DWAVEL'][ww_sci[0]]
+                    hdul[0].header['CWAVEL'] = (database.obs[key]['CWAVEL'][ww_sci[0]], "[micron] Filter pivot wavelength")
+                    hdul[0].header['DWAVEL'] = (database.obs[key]['DWAVEL'][ww_sci[0]], "[micron] Filter effective width")
                     hdul[0].header['PUPIL'] = (database.obs[key]['PUPIL'][ww_sci[0]], head_primary.comments["PUPIL"])
                     hdul[0].header['CORONMSK'] = (database.obs[key]['CORONMSK'][ww_sci[0]], head_primary.comments["CORONMSK"])
                     hdul[0].header['EXP_TYPE'] = (database.obs[key]['EXP_TYPE'][ww_sci[0]], head_primary.comments["EXP_TYPE"])
@@ -200,7 +208,7 @@ def run_obs(database,
                     hdul[0].header['SUBARRAY'] = (database.obs[key]['SUBARRAY'][ww_sci[0]], head_primary.comments["SUBARRAY"])
                     hdul[0].header['APERNAME'] = (database.obs[key]['APERNAME'][ww_sci[0]], head_primary.comments["APERNAME"])
                     hdul[0].header['PPS_APER'] = (database.obs[key]['PPS_APER'][ww_sci[0]], head_primary.comments["PPS_APER"])
-                    hdul[0].header['PIXSCALE'] = database.obs[key]['PIXSCALE'][ww_sci[0]]
+                    hdul[0].header['PIXSCALE'] = (database.obs[key]['PIXSCALE'][ww_sci[0]], "[arcsec/pixel] Pixel scale")
                     try:
                         hdul[0].header['PIXAR_SR'] = (database.obs[key]['PIXAR_SR'][ww_sci[0]], head_sci.comments["PIXAR_SR"])
                     except:
@@ -208,7 +216,6 @@ def run_obs(database,
 
                     hdul[0].header['MODE'] = (mode, "PSF subtraction mode: ADI, RDI, or ADI+RDI")
                     hdul[0].header['ANNULI'] = (annu, "Number of subtraction annuli")
-                    hdul[0].header['ANNULI_S'] = (kwargs['annuli_spacing'], "Radial distribution of annuli: constant, log, or linear")
                     hdul[0].header['SUBSECTS'] = (subs, "Number of subtraction subsections within each annulus")
                     hdul[0].header['BUNIT'] = (database.obs[key]['BUNIT'][ww_sci[0]], head_sci.comments["BUNIT"])
                     w = wcs.WCS(head_sci)
@@ -257,19 +264,19 @@ def run_obs(database,
                             else:
                                 hdul[0].data = np.nanmedian(dataset.allints[:, :, ww, :, :], axis=2)
                             hdul[0].header['NINTS'] = (database.obs[key]['NINTS'][j], head_primary.comments['NINTS'])
-                            hdul[0].header['WCSAXES'] = (head_sci['WCSAXES'], head_primary.comments['WCSAXES'])
-                            hdul[0].header['CRPIX1'] = (head_sci['STARCENX'], head_primary.comments['CRPIX1'])
-                            hdul[0].header['CRPIX2'] = (head_sci['STARCENY'], head_primary.comments['CRPIX2'])
-                            hdul[0].header['CRVAL1'] = (head_sci['CRVAL1'], head_primary.comments['CRVAL1'])
-                            hdul[0].header['CRVAL2'] = (head_sci['CRVAL2'], head_primary.comments['CRVAL2'])
-                            hdul[0].header['CTYPE1'] = (head_sci['CTYPE1'], head_primary.comments['CTYPE1'])
-                            hdul[0].header['CTYPE2'] = (head_sci['CTYPE2'], head_primary.comments['CTYPE2'])
-                            hdul[0].header['CUNIT1'] = (head_sci['CUNIT1'], head_primary.comments['CUNIT1'])
-                            hdul[0].header['CUNIT2'] = (head_sci['CUNIT2'], head_primary.comments['CUNIT2'])
-                            hdul[0].header['CD1_1'] = (head_sci['CD1_1'], head_primary.comments['CD1_1'])
-                            hdul[0].header['CD1_2'] = (head_sci['CD1_2'], head_primary.comments['CD1_2'])
-                            hdul[0].header['CD2_1'] = (head_sci['CD2_1'], head_primary.comments['CD2_1'])
-                            hdul[0].header['CD2_2'] = (head_sci['CD2_2'], head_primary.comments['CD2_2'])
+                            hdul[0].header['WCSAXES'] = (head_sci['WCSAXES'], head_sci.comments['WCSAXES'])
+                            hdul[0].header['CRPIX1'] = (head_sci['STARCENX'], head_sci.comments['CRPIX1'])
+                            hdul[0].header['CRPIX2'] = (head_sci['STARCENY'], head_sci.comments['CRPIX2'])
+                            hdul[0].header['CRVAL1'] = (head_sci['CRVAL1'], head_sci.comments['CRVAL1'])
+                            hdul[0].header['CRVAL2'] = (head_sci['CRVAL2'], head_sci.comments['CRVAL2'])
+                            hdul[0].header['CTYPE1'] = (head_sci['CTYPE1'], head_sci.comments['CTYPE1'])
+                            hdul[0].header['CTYPE2'] = (head_sci['CTYPE2'], head_sci.comments['CTYPE2'])
+                            hdul[0].header['CUNIT1'] = (head_sci['CUNIT1'], head_sci.comments['CUNIT1'])
+                            hdul[0].header['CUNIT2'] = (head_sci['CUNIT2'], head_sci.comments['CUNIT2'])
+                            hdul[0].header['CD1_1'] = (head_sci['CD1_1'], head_sci.comments['CD1_1'])
+                            hdul[0].header['CD1_2'] = (head_sci['CD1_2'], head_sci.comments['CD1_2'])
+                            hdul[0].header['CD2_1'] = (head_sci['CD2_1'], head_sci.comments['CD2_1'])
+                            hdul[0].header['CD2_2'] = (head_sci['CD2_2'], head_sci.comments['CD2_2'])
                             hdul.writeto(datapath.replace('-KLmodes-all.fits', '-KLmodes-all_roll%.0f.fits' % n_roll), output_verify='fix', overwrite=True)
                             hdul.close()
                             n_roll += 1

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -178,53 +178,56 @@ def run_obs(database,
                     
                     # Update reduction header.
                     ww_sci = np.where(database.obs[key]['TYPE'] == 'SCI')[0]
+                    head_primary = fits.getheader(database.obs[key]['FITSFILE'][ww_sci[0]], 0)
                     head_sci = fits.getheader(database.obs[key]['FITSFILE'][ww_sci[0]], 'SCI')
                     head_sci['NAXIS'] = 2
                     hdul = fits.open(datapath)
-                    hdul[0].header['TELESCOP'] = database.obs[key]['TELESCOP'][ww_sci[0]]
-                    hdul[0].header['TARGPROP'] = database.obs[key]['TARGPROP'][ww_sci[0]]
-                    hdul[0].header['TARG_RA'] = database.obs[key]['TARG_RA'][ww_sci[0]]
-                    hdul[0].header['TARG_DEC'] = database.obs[key]['TARG_DEC'][ww_sci[0]]
-                    hdul[0].header['INSTRUME'] = database.obs[key]['INSTRUME'][ww_sci[0]]
-                    hdul[0].header['DETECTOR'] = database.obs[key]['DETECTOR'][ww_sci[0]]
-                    hdul[0].header['FILTER'] = database.obs[key]['FILTER'][ww_sci[0]]
+                    hdul[0].header['TELESCOP'] = (database.obs[key]['TELESCOP'][ww_sci[0]], head_primary.comments["TELESCOP"])
+                    hdul[0].header['TARGPROP'] = (database.obs[key]['TARGPROP'][ww_sci[0]], head_primary.comments["TARGPROP"])
+                    hdul[0].header['TARG_RA'] = (database.obs[key]['TARG_RA'][ww_sci[0]], head_primary.comments["TARG_RA"])
+                    hdul[0].header['TARG_DEC'] = (database.obs[key]['TARG_DEC'][ww_sci[0]], head_primary.comments["TARG_DEC"])
+                    hdul[0].header['INSTRUME'] = (database.obs[key]['INSTRUME'][ww_sci[0]], head_primary.comments["INSTRUME"])
+                    hdul[0].header['DETECTOR'] = (database.obs[key]['DETECTOR'][ww_sci[0]], head_primary.comments["DETECTOR"])
+                    hdul[0].header['FILTER'] = (database.obs[key]['FILTER'][ww_sci[0]], head_primary.comments["FILTER"])
                     hdul[0].header['CWAVEL'] = database.obs[key]['CWAVEL'][ww_sci[0]]
                     hdul[0].header['DWAVEL'] = database.obs[key]['DWAVEL'][ww_sci[0]]
-                    hdul[0].header['PUPIL'] = database.obs[key]['PUPIL'][ww_sci[0]]
-                    hdul[0].header['CORONMSK'] = database.obs[key]['CORONMSK'][ww_sci[0]]
-                    hdul[0].header['EXP_TYPE'] = database.obs[key]['EXP_TYPE'][ww_sci[0]]
-                    hdul[0].header['EXPSTART'] = np.min(database.obs[key]['EXPSTART'][ww_sci])
-                    hdul[0].header['NINTS'] = np.sum(database.obs[key]['NINTS'][ww_sci])
-                    hdul[0].header['EFFINTTM'] = database.obs[key]['EFFINTTM'][ww_sci[0]]
-                    hdul[0].header['SUBARRAY'] = database.obs[key]['SUBARRAY'][ww_sci[0]]
-                    hdul[0].header['APERNAME'] = database.obs[key]['APERNAME'][ww_sci[0]]
-                    hdul[0].header['PPS_APER'] = database.obs[key]['PPS_APER'][ww_sci[0]]
+                    hdul[0].header['PUPIL'] = (database.obs[key]['PUPIL'][ww_sci[0]], head_primary.comments["PUPIL"])
+                    hdul[0].header['CORONMSK'] = (database.obs[key]['CORONMSK'][ww_sci[0]], head_primary.comments["CORONMSK"])
+                    hdul[0].header['EXP_TYPE'] = (database.obs[key]['EXP_TYPE'][ww_sci[0]], head_primary.comments["EXP_TYPE"])
+                    hdul[0].header['EXPSTART'] = (np.min(database.obs[key]['EXPSTART'][ww_sci]), head_primary.comments["EXPSTART"])
+                    hdul[0].header['NINTS'] = (np.sum(database.obs[key]['NINTS'][ww_sci]), head_primary.comments["NINTS"])
+                    hdul[0].header['EFFINTTM'] = (database.obs[key]['EFFINTTM'][ww_sci[0]], head_primary.comments["EFFINTTM"])
+                    hdul[0].header['SUBARRAY'] = (database.obs[key]['SUBARRAY'][ww_sci[0]], head_primary.comments["SUBARRAY"])
+                    hdul[0].header['APERNAME'] = (database.obs[key]['APERNAME'][ww_sci[0]], head_primary.comments["APERNAME"])
+                    hdul[0].header['PPS_APER'] = (database.obs[key]['PPS_APER'][ww_sci[0]], head_primary.comments["PPS_APER"])
                     hdul[0].header['PIXSCALE'] = database.obs[key]['PIXSCALE'][ww_sci[0]]
                     try:
-                        hdul[0].header['PIXAR_SR'] = database.obs[key]['PIXAR_SR'][ww_sci[0]]
+                        hdul[0].header['PIXAR_SR'] = (database.obs[key]['PIXAR_SR'][ww_sci[0]], head_sci.comments["PIXAR_SR"])
                     except:
                         pass
-                    hdul[0].header['MODE'] = mode
-                    hdul[0].header['ANNULI'] = annu
-                    hdul[0].header['SUBSECTS'] = subs
-                    hdul[0].header['BUNIT'] = database.obs[key]['BUNIT'][ww_sci[0]]
+
+                    hdul[0].header['MODE'] = (mode, "PSF subtraction mode: ADI, RDI, or ADI+RDI")
+                    hdul[0].header['ANNULI'] = (annu, "Number of subtraction annuli")
+                    hdul[0].header['ANNULI_S'] = (kwargs['annuli_spacing'], "Radial distribution of annuli: constant, log, or linear")
+                    hdul[0].header['SUBSECTS'] = (subs, "Number of subtraction subsections within each annulus")
+                    hdul[0].header['BUNIT'] = (database.obs[key]['BUNIT'][ww_sci[0]], head_sci.comments["BUNIT"])
                     w = wcs.WCS(head_sci)
                     _rotate_wcs_hdr(w, database.obs[key]['ROLL_REF'][ww_sci[0]])
-                    hdul[0].header['WCSAXES'] = head_sci['WCSAXES']
-                    hdul[0].header['CRPIX1'] = head_sci['STARCENX']
-                    hdul[0].header['CRPIX2'] = head_sci['STARCENY']
-                    hdul[0].header['CRVAL1'] = head_sci['CRVAL1']
-                    hdul[0].header['CRVAL2'] = head_sci['CRVAL2']
-                    hdul[0].header['CTYPE1'] = head_sci['CTYPE1']
-                    hdul[0].header['CTYPE2'] = head_sci['CTYPE2']
-                    hdul[0].header['CUNIT1'] = head_sci['CUNIT1']
-                    hdul[0].header['CUNIT2'] = head_sci['CUNIT2']
-                    hdul[0].header['CD1_1'] = w.wcs.cd[0, 0]
-                    hdul[0].header['CD1_2'] = w.wcs.cd[0, 1]
-                    hdul[0].header['CD2_1'] = w.wcs.cd[1, 0]
-                    hdul[0].header['CD2_2'] = w.wcs.cd[1, 1]
+                    hdul[0].header['WCSAXES'] = (head_sci['WCSAXES'], head_sci.comments["WCSAXES"])
+                    hdul[0].header['CRPIX1'] = (head_sci['STARCENX'], head_sci.comments["CRPIX1"])
+                    hdul[0].header['CRPIX2'] = (head_sci['STARCENY'], head_sci.comments["CRPIX2"])
+                    hdul[0].header['CRVAL1'] = (head_sci['CRVAL1'], head_sci.comments["CRVAL1"])
+                    hdul[0].header['CRVAL2'] = (head_sci['CRVAL2'], head_sci.comments["CRVAL2"])
+                    hdul[0].header['CTYPE1'] = (head_sci['CTYPE1'], head_sci.comments["CTYPE1"])
+                    hdul[0].header['CTYPE2'] = (head_sci['CTYPE2'], head_sci.comments["CTYPE2"])
+                    hdul[0].header['CUNIT1'] = (head_sci['CUNIT1'], head_sci.comments["CUNIT1"])
+                    hdul[0].header['CUNIT2'] = (head_sci['CUNIT2'], head_sci.comments["CUNIT2"])
+                    hdul[0].header['CD1_1'] = (w.wcs.cd[0, 0], head_sci.comments["CD1_1"])
+                    hdul[0].header['CD1_2'] = (w.wcs.cd[0, 1], head_sci.comments["CD1_2"])
+                    hdul[0].header['CD2_1'] = (w.wcs.cd[1, 0], head_sci.comments["CD2_1"])
+                    hdul[0].header['CD2_2'] = (w.wcs.cd[1, 1], head_sci.comments["CD2_2"])
                     if not np.isnan(database.obs[key]['BLURFWHM'][ww_sci[0]]):
-                        hdul[0].header['BLURFWHM'] = database.obs[key]['BLURFWHM'][ww_sci[0]]
+                        hdul[0].header['BLURFWHM'] = (database.obs[key]['BLURFWHM'][ww_sci[0]], "[pixel] FWHM of applied Gaussian blur")
                     hdul.writeto(datapath, output_verify='fix', overwrite=True)
                     hdul.close()
 
@@ -245,6 +248,7 @@ def run_obs(database,
                         n_roll = 1
                         for j in ww_sci:
                             fitsfile = os.path.split(database.obs[key]['FITSFILE'][j])[1]
+                            head_primary = fits.getheader(database.obs[key]['FITSFILE'][j], 0)
                             head_sci = fits.getheader(database.obs[key]['FITSFILE'][j], 'SCI')
                             ww = [k for k in range(len(dataset._filenames)) if fitsfile in dataset._filenames[k]]
                             hdul = fits.open(datapath)
@@ -252,20 +256,20 @@ def run_obs(database,
                                 hdul[0].data = np.nanmedian(dataset.allints[:, :, ww, :, :], axis=(1, 2))
                             else:
                                 hdul[0].data = np.nanmedian(dataset.allints[:, :, ww, :, :], axis=2)
-                            hdul[0].header['NINTS'] = database.obs[key]['NINTS'][j]
-                            hdul[0].header['WCSAXES'] = head_sci['WCSAXES']
-                            hdul[0].header['CRPIX1'] = head_sci['STARCENX']
-                            hdul[0].header['CRPIX2'] = head_sci['STARCENY']
-                            hdul[0].header['CRVAL1'] = head_sci['CRVAL1']
-                            hdul[0].header['CRVAL2'] = head_sci['CRVAL2']
-                            hdul[0].header['CTYPE1'] = head_sci['CTYPE1']
-                            hdul[0].header['CTYPE2'] = head_sci['CTYPE2']
-                            hdul[0].header['CUNIT1'] = head_sci['CUNIT1']
-                            hdul[0].header['CUNIT2'] = head_sci['CUNIT2']
-                            hdul[0].header['CD1_1'] = head_sci['CD1_1']
-                            hdul[0].header['CD1_2'] = head_sci['CD1_2']
-                            hdul[0].header['CD2_1'] = head_sci['CD2_1']
-                            hdul[0].header['CD2_2'] = head_sci['CD2_2']
+                            hdul[0].header['NINTS'] = (database.obs[key]['NINTS'][j], head_primary.comments['NINTS'])
+                            hdul[0].header['WCSAXES'] = (head_sci['WCSAXES'], head_primary.comments['WCSAXES'])
+                            hdul[0].header['CRPIX1'] = (head_sci['STARCENX'], head_primary.comments['CRPIX1'])
+                            hdul[0].header['CRPIX2'] = (head_sci['STARCENY'], head_primary.comments['CRPIX2'])
+                            hdul[0].header['CRVAL1'] = (head_sci['CRVAL1'], head_primary.comments['CRVAL1'])
+                            hdul[0].header['CRVAL2'] = (head_sci['CRVAL2'], head_primary.comments['CRVAL2'])
+                            hdul[0].header['CTYPE1'] = (head_sci['CTYPE1'], head_primary.comments['CTYPE1'])
+                            hdul[0].header['CTYPE2'] = (head_sci['CTYPE2'], head_primary.comments['CTYPE2'])
+                            hdul[0].header['CUNIT1'] = (head_sci['CUNIT1'], head_primary.comments['CUNIT1'])
+                            hdul[0].header['CUNIT2'] = (head_sci['CUNIT2'], head_primary.comments['CUNIT2'])
+                            hdul[0].header['CD1_1'] = (head_sci['CD1_1'], head_primary.comments['CD1_1'])
+                            hdul[0].header['CD1_2'] = (head_sci['CD1_2'], head_primary.comments['CD1_2'])
+                            hdul[0].header['CD2_1'] = (head_sci['CD2_1'], head_primary.comments['CD2_1'])
+                            hdul[0].header['CD2_2'] = (head_sci['CD2_2'], head_primary.comments['CD2_2'])
                             hdul.writeto(datapath.replace('-KLmodes-all.fits', '-KLmodes-all_roll%.0f.fits' % n_roll), output_verify='fix', overwrite=True)
                             hdul.close()
                             n_roll += 1

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -184,11 +184,10 @@ def run_obs(database,
                     hdul = fits.open(datapath)
                     
                     # Adding comments to a handful of the FITS header keywords populated by pyKLIP.
-                    hdul[0].header.comments['PSFCENTX'] = '[pixel] PSF center along the x axis'
-                    hdul[0].header.comments['PSFCENTY'] = '[pixel] PSF center along the x axis'
+                    hdul[0].header.comments['PSFCENTX'] = 'Star center along the X axis, 0-indexed'
+                    hdul[0].header.comments['PSFCENTY'] = 'Star center along the Y axis, 0-indexed'
                     hdul[0].header.comments['STARCENX'] = 'Star center along the X axis, 1-indexed'
                     hdul[0].header.comments['STARCENY'] = 'Star center along the Y axis, 1-indexed'
-
                     
                     hdul[0].header['TELESCOP'] = (database.obs[key]['TELESCOP'][ww_sci[0]], head_primary.comments["TELESCOP"])
                     hdul[0].header['TARGPROP'] = (database.obs[key]['TARGPROP'][ww_sci[0]], head_primary.comments["TARGPROP"])


### PR DESCRIPTION
Stage 2 FITS products are already well documented by the JWST pipeline. However, the Stage 3 products generated after KLIP processing lack comments. Since many of the header keywords are transferred directly from the Stage 2 JWST pipeline products, I also copied their existing comments to maintain consistency between the Stage 2 and Stage 3 files. Additional comments were added manually for other keywords.

Closes #116 