### PR TITLE
Add center keywords to JWSTData in inject_and_recover

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -576,7 +576,11 @@ class AnalysisTools():
                 # Read Stage 2 files and make pyKLIP dataset
                 filepaths, psflib_filepaths = get_pyklip_filepaths(self.database, key)
                 pop_pxar_kw(np.append(filepaths, psflib_filepaths))
-                pyklip_dataset = JWSTData(filepaths, psflib_filepaths)
+                
+                # TODO: track highpass argument to match JWSTData created in pyklippipeline.run_obs()
+                pyklip_dataset = JWSTData(filepaths, psflib_filepaths,
+                                          center_include_offset=False,
+                                          center_keywords=['STARCENX','STARCENY'])
 
                 # Compute the resolution element. Account for possible blurring.
                 pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] # arcsec


### PR DESCRIPTION
In `analysistools.calibrate_contrast()`, when injecting fake planets inside `inject_and_recover`, the `JWSTData` class created is not identical to the `JWSTData` class used in `pyklippipeline.run_obs()`. It is missing the `center_include_offset` and `center_keywords` keywords. As a result, the KLIP subtractions during the fake planet injection routine to measure throughput do not match the actual KLIP subtractions, even when injecting a fake planet with 0 flux (`injection_flux_sigma=0`) which should match exactly. This ends up affecting the algorithm throughput and therefore the calibrated contrast curve. Below is an example on 14 Her:

<img width="521" height="435" alt="image" src="https://github.com/user-attachments/assets/7360a623-c2c9-4084-a3bb-f7d652276942" />
<img width="582" height="435" alt="image" src="https://github.com/user-attachments/assets/2be67473-6618-4801-bf3f-2b4b558aee3f" />

Adding the two keywords to the `JWSTData` object solves this issue. Example below, showing that the difference between the KLIP subtraction and the KLIP subtraction with a 0 flux fake planet is now 0, as expected:

<img width="582" height="435" alt="image" src="https://github.com/user-attachments/assets/89feae34-e847-4ee0-9328-d25a08203adb" />
<img width="529" height="456" alt="image" src="https://github.com/user-attachments/assets/03284e40-71f3-42be-b832-eadda6a1b10c" />

On the other hand, the `JWSTData` object in `inject_and_recover` is still missing the `highpass` keyword that can be passed through `pyklippipeline.run_obs()`, so if someone uses that keyword there could be a similar problem. From what I see in the code, the value of `highpass` used in `pyklippipeline.run_obs()` is not tracked and it's just assumed to be `False` in `inject_and_recover,` so when that starts being tracked in the future it should be changed in `inject_and_recover` as well

 